### PR TITLE
Toast updates

### DIFF
--- a/.claude/skills/components/display-toast.md
+++ b/.claude/skills/components/display-toast.md
@@ -131,6 +131,7 @@ const { show, dismiss, clear, queue } = useToastQueue()
 | Method | Signature | Notes |
 |---|---|---|
 | `show(config)` | `(config: DisplayToastConfig) => string` | Adds a toast to the queue; returns its ID |
+| `promote(id)` | `(id: string) => void` | Internal: marks a queued toast as `visible` (used by `DisplayToastProvider`) |
 | `dismiss(id)` | `(id: string) => void` | Removes a specific toast by ID |
 | `clear()` | `() => void` | Flushes all pending and visible toasts |
 | `queue` | `Readonly<Ref<ToastQueueEntry[]>>` | Reactive read-only queue state |

--- a/.claude/skills/components/display-toast.md
+++ b/.claude/skills/components/display-toast.md
@@ -1,25 +1,38 @@
-# DisplayToast
+# DisplayToast / DisplayToastProvider
 
 ## Overview
 
-`DisplayToast` is a notification toast that teleports to `<body>` and is triggered via `v-model`.
-It supports four semantic themes, configurable position/alignment, auto-dismiss with a progress bar,
-and optional custom slot content. The inner content is rendered by `DefaultToastContent` unless a
-default slot is provided.
+Two patterns are available depending on the use case:
 
-**Location**: `app/components/01.atoms/toast/DisplayToast.vue`
-**Inner molecule**: `app/components/01.atoms/toast/molecules/DefaultToastContent.vue`
-**Types**: `~/types/components` — `DisplayToastConfig`, `DisplayToastTheme`, `SemanticTheme`
+| Pattern | Component | When to use |
+|---|---|---|
+| **Standalone** | `DisplayToast` | One-off toast tied to a specific UI action; no queueing needed |
+| **App-wide queue** | `DisplayToastProvider` + `useToastQueue` | Multiple toasts across the app, stacking, queue management |
 
-## Props
+**Locations**:
+
+- `app/components/01.atoms/toast/DisplayToast.vue`
+- `app/components/01.atoms/toast/DisplayToastProvider.vue`
+- `app/composables/useToastQueue.ts`
+- `app/components/01.atoms/toast/molecules/DefaultToastContent.vue`
+
+**Types**: `~/types/components` — `DisplayToastConfig`, `DisplayToastTheme`, `ToastQueueEntry`, `ToastQueueStatus`
+
+---
+
+## Pattern 1 — Standalone (`DisplayToast`)
+
+Triggered via `v-model`. Each instance manages its own visibility and position.
+
+### Props
 
 | Prop | Type | Default | Notes |
 |---|---|---|---|
-| `v-model` | `boolean` | `false` | Setting to `true` shows the toast; setting back to `false` hides it. |
-| `config` | `DisplayToastConfig` | see below | Full config object — all sub-keys are optional. |
-| `styleClassPassthrough` | `string \| string[]` | `[]` | Extra classes applied to the toast root element. |
+| `v-model` | `boolean` | `false` | `true` shows; `false` hides. |
+| `config` | `DisplayToastConfig` | see below | All sub-keys optional. |
+| `styleClassPassthrough` | `string \| string[]` | `[]` | Extra classes on the root element. |
 
-### config shape
+### Config shape
 
 ```ts
 interface DisplayToastConfig {
@@ -44,34 +57,16 @@ interface DisplayToastConfig {
 }
 ```
 
-## Slots
+### Slots
 
 | Slot | Description |
 |---|---|
-| `default` | Replaces `DefaultToastContent` entirely — use for fully custom toast bodies. `has-theme` class and accessibility attributes are omitted when this slot is used. |
-| `#customToastIcon` | Replaces the default theme icon. Only forwarded to `DefaultToastContent` when provided. |
-| `#title` | Replaces the `config.content.title` text. Only forwarded when provided — do not provide both slot and `config.content.title`. |
-| `#description` | Replaces the `config.content.description` text. Only forwarded when provided. |
+| `default` | Replaces `DefaultToastContent` entirely. `has-theme`, `tabindex`, and `aria-describedby` are omitted — accessibility is the caller's responsibility. |
+| `#customToastIcon` | Replaces the default theme icon. |
+| `#title` | Replaces `config.content.title`. Do not provide both slot and config value. |
+| `#description` | Replaces `config.content.description`. Do not provide both slot and config value. |
 
-> **Slot forwarding note**: `#title`, `#description`, and `#customToastIcon` are conditionally
-> forwarded to `DefaultToastContent`. If you provide the slot, `DefaultToastContent` uses the slot;
-> if not, it falls back to the `config.content.*` value. Never provide both — the slot wins.
-
-## Themes and ARIA
-
-Theme drives both colour and ARIA behaviour:
-
-| Theme | ARIA role | aria-live |
-|---|---|---|
-| `"info"` | `status` | `polite` |
-| `"success"` | `status` | `polite` |
-| `"warning"` | `alert` | `assertive` |
-| `"error"` | `alert` | `assertive` |
-
-The `data-theme` attribute on the root element activates the CSS palette via the project's
-theming system (`--theme-surface`, `--theme-text`, `--theme-border`, etc.).
-
-## Basic usage — simple text
+### Basic usage
 
 ```vue
 <script setup lang="ts">
@@ -92,71 +87,119 @@ const toastVisible = ref(false)
 </template>
 ```
 
-## Title + description
+### Notes
+
+- `onBeforeRouteLeave` dismisses the toast on navigation. This emits a Vue Router warning in Vitest (no active route record) — harmless.
+- `returnFocusTo` accepts an `HTMLElement` or a component instance with `$el`.
+- The toast uses `<Teleport to="body">`. In tests, query `document.querySelector(".display-toast")` not `wrapper.find()`.
+
+---
+
+## Pattern 2 — App-wide queue (`DisplayToastProvider` + `useToastQueue`)
+
+Place `DisplayToastProvider` once in the app layout. Trigger toasts from anywhere using `useToastQueue`. The provider promotes pending entries to visible up to `maxVisible`, manages timers, and handles stacked FLIP animations.
+
+### Setup — layout
 
 ```vue
-<DisplayToast
-  v-model="toastVisible"
-  :config="{
-    appearance: { theme: 'error', position: 'top', alignment: 'right' },
-    behavior: { autoDismiss: false },
-    content: {
-      title: 'Save failed',
-      description: 'Check your connection and try again.',
-    },
-  }"
-/>
-```
-
-## Custom slot content
-
-When the `default` slot is used, `has-theme`, `tabindex`, and `aria-describedby` are removed —
-full accessibility is the caller's responsibility.
-
-```vue
-<DisplayToast v-model="toastVisible">
-  <div class="my-toast-body">
-    <p>Custom content here</p>
+<!-- layouts/default.vue -->
+<template>
+  <div>
+    <slot />
+    <DisplayToastProvider position="top" alignment="right" :max-visible="1" />
   </div>
-</DisplayToast>
+</template>
 ```
 
-## Position and alignment
+Only one `DisplayToastProvider` should be mounted at a time. It uses `<Teleport to="body">` so its placement in the layout tree does not affect visual output.
 
-| Config | Result |
-|---|---|
-| `position: "top"`, `alignment: "right"` | Top-right (default) |
-| `position: "bottom"`, `alignment: "center"` | Bottom-centre |
-| `fullWidth: true` | Spans full viewport width; alignment is ignored |
+### `DisplayToastProvider` props
 
-On screens narrower than 600 px the toast always spans the full inline width regardless of `alignment`.
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `position` | `"top" \| "bottom"` | `"top"` | Vertical screen edge |
+| `alignment` | `"left" \| "center" \| "right"` | `"right"` | Horizontal alignment (ignored when `fullWidth`) |
+| `fullWidth` | `boolean` | `false` | Toast spans the full viewport width |
+| `maxVisible` | `number` | `1` | Max toasts visible simultaneously; rest queue as pending |
 
-## Progress bar
+### `useToastQueue` API
 
-When `autoDismiss: true` a thin progress bar animates across the bottom of the toast over
-`duration` ms. It is removed when `autoDismiss: false`.
+```ts
+const { show, dismiss, clear, queue } = useToastQueue()
+```
 
-## CSS
+| Method | Signature | Notes |
+|---|---|---|
+| `show(config)` | `(config: DisplayToastConfig) => string` | Adds a toast to the queue; returns its ID |
+| `dismiss(id)` | `(id: string) => void` | Removes a specific toast by ID |
+| `clear()` | `() => void` | Flushes all pending and visible toasts |
+| `queue` | `Readonly<Ref<ToastQueueEntry[]>>` | Reactive read-only queue state |
 
-The toast uses `--theme-*` semantic slots from the theming system. Direct token overrides via
-`styleClassPassthrough`:
+The composable uses a **module-level singleton** — state is shared across all callers without Pinia. Safe for client-only ephemeral UI state.
+
+### Triggering toasts
 
 ```vue
-<DisplayToast style-class-passthrough="my-toast" ... />
+<script setup lang="ts">
+const { show } = useToastQueue()
+
+const onSave = async () => {
+  try {
+    await save()
+    show({
+      appearance: { theme: 'success' },
+      behavior: { autoDismiss: true, duration: 4000 },
+      content: { title: 'Saved', description: 'Your changes have been saved.' },
+    })
+  } catch {
+    show({
+      appearance: { theme: 'error' },
+      behavior: { autoDismiss: false },
+      content: { title: 'Save failed', description: 'Check your connection and try again.' },
+    })
+  }
+}
+</script>
 ```
+
+### Stacking (`maxVisible > 1`)
+
+```vue
+<DisplayToastProvider :max-visible="3" position="top" alignment="right" />
+```
+
+With `maxVisible: 3` and 5 toasts triggered:
+
+- Toasts 1–3 are visible immediately
+- Toasts 4–5 queue as `pending`
+- When toast 1 is dismissed, toast 4 is promoted and animates in
+
+Stacked dismissals use a FLIP animation — remaining toasts slide smoothly to fill the gap rather than snapping.
+
+### Themes and ARIA
+
+| Theme | ARIA role | aria-live |
+|---|---|---|
+| `"info"` | `status` | `polite` |
+| `"success"` | `status` | `polite` |
+| `"warning"` | `alert` | `assertive` |
+| `"error"` | `alert` | `assertive` |
+
+### CSS / styling
+
+Override tokens via an unscoped style block scoped to a page or layout class:
 
 ```css
-.my-toast.display-toast {
-  --theme-surface: oklch(60% 0.15 140);
+.my-page .display-toast-provider-item {
+  --theme-surface: oklch(15% 0 0);
+  --theme-text: oklch(95% 0 0);
 }
 ```
 
-## Notes
+### Provider notes
 
-- The component uses `<Teleport to="body">` — the toast DOM is always a direct child of
-  `<body>`, not inside the mounting component's subtree. In tests, use
-  `document.querySelector(".display-toast")` not `wrapper.find()`.
-- `onBeforeRouteLeave` dismisses the toast on navigation. This emits a Vue Router warning in
-  Vitest environments (no active route record) — it is harmless and can be ignored.
-- `returnFocusTo` accepts either an `HTMLElement` or a component instance with `$el`.
-- Type: `DisplayToastTheme` is an alias for `SemanticTheme` (`"info" | "success" | "warning" | "error"`).
+- `useToastQueue` state persists across route changes — no `onBeforeRouteLeave` cleanup needed.
+- `crypto.randomUUID()` generates toast IDs (`toast-<uuid>`). IDs are returned by `show()` for targeted `dismiss(id)` calls.
+- In tests, query via `document.querySelector(".display-toast-provider-item")` — the Teleport renders outside the component wrapper.
+- The progress bar (`.display-toast-provider-progress`) is only rendered when `autoDismiss: true`.
+- Dismissal can be triggered by: close button click, Escape key (when the toast item has focus), `dismiss(id)`, auto-dismiss timer, or `clear()`.

--- a/.claude/skills/components/display-toast.md
+++ b/.claude/skills/components/display-toast.md
@@ -131,12 +131,13 @@ const { show, dismiss, clear, queue } = useToastQueue()
 | Method | Signature | Notes |
 |---|---|---|
 | `show(config)` | `(config: DisplayToastConfig) => string` | Adds a toast to the queue; returns its ID |
-| `promote(id)` | `(id: string) => void` | Internal: marks a queued toast as `visible` (used by `DisplayToastProvider`) |
 | `dismiss(id)` | `(id: string) => void` | Removes a specific toast by ID |
 | `clear()` | `() => void` | Flushes all pending and visible toasts |
 | `queue` | `Readonly<Ref<ToastQueueEntry[]>>` | Reactive read-only queue state |
 
 The composable uses a **module-level singleton** — state is shared across all callers without Pinia. Safe for client-only ephemeral UI state.
+
+> **Internal API**: `DisplayToastProvider` uses `useToastQueueProvider()` (a separate export from the same file) which additionally exposes `promote`. Do not call `useToastQueueProvider` from consuming app code — manually promoting without a timer puts the queue into an inconsistent state.
 
 ### Triggering toasts
 

--- a/.claude/skills/index.md
+++ b/.claude/skills/index.md
@@ -92,7 +92,7 @@ Each skill is a single markdown file named `<area>-<task>.md`.
     ├── display-pill.md         — DisplayPill: pill/badge label with icon slot, 6 variants, 3 sizes, reversible order, full CSS token API for border/outline/colour
     ├── carousel-flip.md        — CarouselFlip: FLIP-animated carousel, carouselDataIds slot API, buttonLayout variants (sides/controls-flanking/controls-grouped-right/overlay), CSS tokens
     ├── samaritan-prompt-mixed.md — SamaritanPromptMixed: animated text prompt, typewriter/word-pulse effects, MessageConfig API, aria-live accessibility, CSS tokens
-    ├── display-toast.md          — DisplayToast: Teleport-based notification toast, SemanticTheme × 4, config object API, autoDismiss, position/alignment, slot forwarding gotcha
+    ├── display-toast.md          — DisplayToast (standalone v-model) + DisplayToastProvider + useToastQueue (app-wide queue): stacking, FLIP dismiss, maxVisible, SemanticTheme × 4
     └── display-prompt.md         — DisplayPrompt: inline notification banner, SemanticTheme × 4, local vs parent-controlled dismiss, outlined modifier, CSS token override
 ```
 

--- a/app/components/01.atoms/toast/DisplayToastProvider.vue
+++ b/app/components/01.atoms/toast/DisplayToastProvider.vue
@@ -4,6 +4,7 @@
       tag="div"
       class="display-toast-provider"
       :class="[position, fullWidth ? 'full-width' : alignment]"
+      @before-leave="onBeforeLeave"
       @after-enter="onAfterEnter"
     >
       <div
@@ -117,6 +118,12 @@ const setItemRef = (id: string, el: HTMLElement | null) => {
   else itemRefs.delete(id);
 };
 
+const onBeforeLeave = (el: Element) => {
+  const htmlEl = el as HTMLElement;
+  htmlEl.style.top = `${htmlEl.offsetTop}px`;
+  htmlEl.style.width = `${htmlEl.offsetWidth}px`;
+};
+
 const onAfterEnter = (el: Element) => {
   (el as HTMLElement).focus();
 };
@@ -206,6 +213,8 @@ onUnmounted(() => {
       }
 
       &.v-leave-active {
+        position: absolute;
+
         @supports (animation-timing-function: linear(0, 1)) {
           animation: hideTop var(--_reveal) var(--spring-easing) forwards;
         }
@@ -223,6 +232,8 @@ onUnmounted(() => {
       }
 
       &.v-leave-active {
+        position: absolute;
+
         @supports (animation-timing-function: linear(0, 1)) {
           animation: hideBottom var(--_reveal) var(--spring-easing) forwards;
         }

--- a/app/components/01.atoms/toast/DisplayToastProvider.vue
+++ b/app/components/01.atoms/toast/DisplayToastProvider.vue
@@ -101,6 +101,16 @@ watch(
   queue,
   (newQueue) => {
     const entries = newQueue as ToastQueueEntry[];
+
+    // Clear timers for entries that no longer exist (e.g. clear()).
+    const entryIds = new Set(entries.map((e) => e.id));
+    for (const [id, timer] of timers) {
+      if (!entryIds.has(id)) {
+        clearTimeout(timer);
+        timers.delete(id);
+      }
+    }
+
     const visibleCount = entries.filter((e) => e.status === "visible").length;
     const slots = props.maxVisible - visibleCount;
     const pending = entries.filter((e) => e.status === "pending");

--- a/app/components/01.atoms/toast/DisplayToastProvider.vue
+++ b/app/components/01.atoms/toast/DisplayToastProvider.vue
@@ -11,7 +11,6 @@
       <div
         v-for="entry in visibleEntries"
         :key="entry.id"
-        :ref="(el) => setItemRef(entry.id, el as HTMLElement | null)"
         class="display-toast-provider-item has-theme"
         :style="{
           '--_reveal': revealDurationFor(entry) + 'ms',

--- a/app/components/01.atoms/toast/DisplayToastProvider.vue
+++ b/app/components/01.atoms/toast/DisplayToastProvider.vue
@@ -136,6 +136,28 @@ onUnmounted(() => {
 
 <style lang="css">
 @layer components {
+  @keyframes showTop {
+    from {
+      opacity: 0;
+      transform: translateY(-30px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes showBottom {
+    from {
+      opacity: 0;
+      transform: translateY(30px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
   .display-toast-provider {
     --_gutter: 12px;
     @media (width >= 600px) {
@@ -212,6 +234,16 @@ onUnmounted(() => {
         transform: translateY(-30px);
       }
 
+      &.v-enter-active {
+        @supports (animation-timing-function: linear(0, 1)) {
+          animation: showTop var(--_reveal) var(--spring-easing) forwards;
+        }
+
+        @supports not (animation-timing-function: linear(0, 1)) {
+          animation: showTop calc(var(--_reveal) / 2) linear forwards;
+        }
+      }
+
       &.v-leave-active {
         position: absolute;
 
@@ -231,6 +263,16 @@ onUnmounted(() => {
         transform: translateY(30px);
       }
 
+      &.v-enter-active {
+        @supports (animation-timing-function: linear(0, 1)) {
+          animation: showBottom var(--_reveal) var(--spring-easing) forwards;
+        }
+
+        @supports not (animation-timing-function: linear(0, 1)) {
+          animation: showBottom calc(var(--_reveal) / 2) linear forwards;
+        }
+      }
+
       &.v-leave-active {
         position: absolute;
 
@@ -241,16 +283,6 @@ onUnmounted(() => {
         @supports not (animation-timing-function: linear(0, 1)) {
           animation: hideBottom calc(var(--_reveal) / 2) linear forwards;
         }
-      }
-    }
-
-    &.v-enter-active {
-      @supports (animation-timing-function: linear(0, 1)) {
-        animation: show var(--_reveal) var(--spring-easing) forwards;
-      }
-
-      @supports not (animation-timing-function: linear(0, 1)) {
-        animation: show calc(var(--_reveal) / 2) linear forwards;
       }
     }
 

--- a/app/components/01.atoms/toast/DisplayToastProvider.vue
+++ b/app/components/01.atoms/toast/DisplayToastProvider.vue
@@ -158,6 +158,34 @@ onUnmounted(() => {
 
 <style lang="css">
 @layer components {
+  @keyframes hideTop {
+    0% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    100% {
+      opacity: 0;
+      transform: translateY(-30px);
+    }
+  }
+
+  @keyframes hideBottom {
+    0% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    100% {
+      opacity: 0;
+      transform: translateY(30px);
+    }
+  }
+
+  @keyframes progress {
+    to {
+      transform: scaleX(1);
+    }
+  }
+
   @keyframes showTop {
     from {
       opacity: 0;

--- a/app/components/01.atoms/toast/DisplayToastProvider.vue
+++ b/app/components/01.atoms/toast/DisplayToastProvider.vue
@@ -1,0 +1,274 @@
+<template>
+  <Teleport to="body">
+    <TransitionGroup
+      tag="div"
+      class="display-toast-provider"
+      :class="[position, fullWidth ? 'full-width' : alignment]"
+      @after-enter="onAfterEnter"
+    >
+      <div
+        v-for="entry in visibleEntries"
+        :key="entry.id"
+        :ref="(el) => setItemRef(entry.id, el as HTMLElement | null)"
+        class="display-toast-provider-item has-theme"
+        :style="{
+          '--_reveal': revealDurationFor(entry) + 'ms',
+          '--_duration': displayDurationFor(entry) + 'ms',
+        }"
+        :data-theme="themeFor(entry)"
+        :role="roleFor(entry)"
+        :aria-live="ariaLiveFor(entry)"
+        tabindex="0"
+        :aria-describedby="'toast-message-' + entry.id"
+        @keydown.escape="handleDismiss(entry.id)"
+      >
+        <DefaultToastContent
+          :theme="themeFor(entry)"
+          :custom-icon="entry.config.content?.customIcon"
+          :toast-id="entry.id"
+          :toast-display-text="entry.config.content?.text ?? ''"
+          :toast-title="entry.config.content?.title ?? ''"
+          :toast-description="entry.config.content?.description ?? ''"
+          :auto-dismiss="autoDismissFor(entry)"
+          :set-dismiss-toast="() => handleDismiss(entry.id)"
+        />
+        <div v-if="autoDismissFor(entry)" class="display-toast-provider-progress"></div>
+      </div>
+    </TransitionGroup>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import type {
+  DisplayToastTheme,
+  DisplayToastPosition,
+  DisplayToastAlignment,
+  ToastQueueEntry,
+} from "~/types/components";
+
+interface Props {
+  position?: DisplayToastPosition;
+  alignment?: DisplayToastAlignment;
+  fullWidth?: boolean;
+  maxVisible?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  position: "top",
+  alignment: "right",
+  fullWidth: false,
+  maxVisible: 1,
+});
+
+const { queue, promote, dismiss } = useToastQueue();
+
+const visibleEntries = computed<ToastQueueEntry[]>(() =>
+  (queue.value as ToastQueueEntry[]).filter((e) => e.status === "visible")
+);
+
+const themeFor = (entry: ToastQueueEntry): DisplayToastTheme => entry.config.appearance?.theme ?? "info";
+const autoDismissFor = (entry: ToastQueueEntry) => entry.config.behavior?.autoDismiss ?? true;
+const displayDurationFor = (entry: ToastQueueEntry) => entry.config.behavior?.duration ?? 5000;
+const revealDurationFor = (entry: ToastQueueEntry) => entry.config.behavior?.revealDuration ?? 550;
+const roleFor = (entry: ToastQueueEntry) =>
+  ["error", "warning"].includes(themeFor(entry)) ? "alert" : "status";
+const ariaLiveFor = (entry: ToastQueueEntry) =>
+  ["error", "warning"].includes(themeFor(entry)) ? "assertive" : "polite";
+
+const timers = new Map<string, ReturnType<typeof setTimeout>>();
+
+const handleDismiss = (id: string) => {
+  const timer = timers.get(id);
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    timers.delete(id);
+  }
+  dismiss(id);
+};
+
+const startTimer = (entry: ToastQueueEntry) => {
+  if (!autoDismissFor(entry)) return;
+  const timer = setTimeout(() => {
+    timers.delete(entry.id);
+    dismiss(entry.id);
+  }, displayDurationFor(entry));
+  timers.set(entry.id, timer);
+};
+
+watch(
+  queue,
+  (newQueue) => {
+    const entries = newQueue as ToastQueueEntry[];
+    const visibleCount = entries.filter((e) => e.status === "visible").length;
+    const slots = props.maxVisible - visibleCount;
+    const pending = entries.filter((e) => e.status === "pending");
+    for (let i = 0; i < Math.min(slots, pending.length); i++) {
+      promote(pending[i]!.id);
+      startTimer(pending[i]!);
+    }
+  },
+  { immediate: true }
+);
+
+const itemRefs = new Map<string, HTMLElement>();
+
+const setItemRef = (id: string, el: HTMLElement | null) => {
+  if (el) itemRefs.set(id, el);
+  else itemRefs.delete(id);
+};
+
+const onAfterEnter = (el: Element) => {
+  (el as HTMLElement).focus();
+};
+
+onUnmounted(() => {
+  timers.forEach(clearTimeout);
+  timers.clear();
+});
+</script>
+
+<style lang="css">
+@layer components {
+  .display-toast-provider {
+    --_gutter: 12px;
+    @media (width >= 600px) {
+      --_gutter: 24px;
+    }
+
+    position: fixed;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    z-index: 100;
+
+    inset-inline: var(--_gutter);
+    margin-inline: auto;
+    width: max-content;
+    max-width: calc(100% - 2 * var(--_gutter));
+
+    &.top {
+      inset-block-start: var(--_gutter);
+    }
+
+    &.bottom {
+      inset-block-end: var(--_gutter);
+      flex-direction: column-reverse;
+    }
+
+    @media (width >= 600px) {
+      &.left {
+        inset-inline-start: var(--_gutter);
+        inset-inline-end: unset;
+        margin-inline: 0;
+      }
+
+      &.right {
+        inset-inline-end: var(--_gutter);
+        inset-inline-start: unset;
+        margin-inline: 0;
+      }
+
+      &.center:not(.full-width) {
+        inset-inline: 0;
+        margin-inline: auto;
+      }
+
+      &.full-width {
+        inset-inline: var(--_gutter);
+        width: unset;
+        max-width: unset;
+      }
+    }
+  }
+
+  .display-toast-provider-item {
+    --_reveal: 550ms;
+    --_duration: 5000ms;
+
+    display: block;
+    position: relative;
+    overflow: hidden;
+
+    &:focus {
+      outline: 2px solid var(--theme-ring);
+      outline-offset: 2px;
+    }
+
+    &:focus:not(:focus-visible) {
+      outline: none;
+    }
+
+    /* TransitionGroup enter/leave */
+    .display-toast-provider.top & {
+      &.v-enter-from {
+        opacity: 0;
+        transform: translateY(-30px);
+      }
+
+      &.v-leave-active {
+        @supports (animation-timing-function: linear(0, 1)) {
+          animation: hideTop var(--_reveal) var(--spring-easing) forwards;
+        }
+
+        @supports not (animation-timing-function: linear(0, 1)) {
+          animation: hideTop calc(var(--_reveal) / 2) linear forwards;
+        }
+      }
+    }
+
+    .display-toast-provider.bottom & {
+      &.v-enter-from {
+        opacity: 0;
+        transform: translateY(30px);
+      }
+
+      &.v-leave-active {
+        @supports (animation-timing-function: linear(0, 1)) {
+          animation: hideBottom var(--_reveal) var(--spring-easing) forwards;
+        }
+
+        @supports not (animation-timing-function: linear(0, 1)) {
+          animation: hideBottom calc(var(--_reveal) / 2) linear forwards;
+        }
+      }
+    }
+
+    &.v-enter-active {
+      @supports (animation-timing-function: linear(0, 1)) {
+        animation: show var(--_reveal) var(--spring-easing) forwards;
+      }
+
+      @supports not (animation-timing-function: linear(0, 1)) {
+        animation: show calc(var(--_reveal) / 2) linear forwards;
+      }
+    }
+
+    &.v-move {
+      transition: transform 0.3s ease;
+    }
+
+    &.has-theme {
+      padding-inline-start: 6px;
+      background-color: var(--theme-surface);
+      border: 0.1rem solid var(--theme-border);
+      border-start-start-radius: 8px;
+      border-end-start-radius: 8px;
+      border-start-end-radius: 4px;
+      border-end-end-radius: 4px;
+      overflow: hidden;
+    }
+
+    .display-toast-provider-progress {
+      position: absolute;
+      inset-block-end: 4px;
+      inset-inline: 15px 8px;
+      height: 3px;
+      transform: scaleX(0);
+      transform-origin: right;
+      background: var(--theme-surface);
+      border-radius: inherit;
+      animation: progress var(--_duration) linear forwards;
+    }
+  }
+}
+</style>

--- a/app/components/01.atoms/toast/DisplayToastProvider.vue
+++ b/app/components/01.atoms/toast/DisplayToastProvider.vue
@@ -61,7 +61,7 @@ const props = withDefaults(defineProps<Props>(), {
   maxVisible: 1,
 });
 
-const { queue, promote, dismiss } = useToastQueue();
+const { queue, promote, dismiss } = useToastQueueProvider();
 
 const visibleEntries = computed<ToastQueueEntry[]>(() =>
   (queue.value as ToastQueueEntry[]).filter((e) => e.status === "visible")

--- a/app/components/01.atoms/toast/DisplayToastProvider.vue
+++ b/app/components/01.atoms/toast/DisplayToastProvider.vue
@@ -5,6 +5,7 @@
       class="display-toast-provider"
       :class="[position, fullWidth ? 'full-width' : alignment]"
       @before-leave="onBeforeLeave"
+      @after-leave="onAfterLeave"
       @after-enter="onAfterEnter"
     >
       <div
@@ -118,10 +119,28 @@ const setItemRef = (id: string, el: HTMLElement | null) => {
   else itemRefs.delete(id);
 };
 
+let _leavingCount = 0;
+let _containerEl: HTMLElement | null = null;
+
 const onBeforeLeave = (el: Element) => {
   const htmlEl = el as HTMLElement;
+  if (_leavingCount === 0) {
+    _containerEl = htmlEl.parentElement as HTMLElement;
+    if (_containerEl) {
+      _containerEl.style.minWidth = `${_containerEl.offsetWidth}px`;
+    }
+  }
+  _leavingCount++;
   htmlEl.style.top = `${htmlEl.offsetTop}px`;
   htmlEl.style.width = `${htmlEl.offsetWidth}px`;
+};
+
+const onAfterLeave = () => {
+  _leavingCount--;
+  if (_leavingCount === 0 && _containerEl) {
+    _containerEl.style.minWidth = "";
+    _containerEl = null;
+  }
 };
 
 const onAfterEnter = (el: Element) => {

--- a/app/components/01.atoms/toast/DisplayToastProvider.vue
+++ b/app/components/01.atoms/toast/DisplayToastProvider.vue
@@ -121,12 +121,6 @@ watch(
   { immediate: true }
 );
 
-const itemRefs = new Map<string, HTMLElement>();
-
-const setItemRef = (id: string, el: HTMLElement | null) => {
-  if (el) itemRefs.set(id, el);
-  else itemRefs.delete(id);
-};
 
 let _leavingCount = 0;
 let _containerEl: HTMLElement | null = null;

--- a/app/components/01.atoms/toast/stories/DisplayToastProvider.stories.ts
+++ b/app/components/01.atoms/toast/stories/DisplayToastProvider.stories.ts
@@ -1,0 +1,142 @@
+import type { Meta, StoryFn } from "@nuxtjs/storybook";
+import { useToastQueue } from "~/composables/useToastQueue";
+import DisplayToastProvider from "../DisplayToastProvider.vue";
+import type { DisplayToastTheme, DisplayToastPosition, DisplayToastAlignment } from "~/types/components";
+
+type StoryArgs = {
+  position: DisplayToastPosition;
+  alignment: DisplayToastAlignment;
+  fullWidth: boolean;
+  maxVisible: number;
+  theme: DisplayToastTheme;
+  autoDismiss: boolean;
+  duration: number;
+};
+
+const themes = ["info", "success", "warning", "error"] as const;
+
+const messages: Record<DisplayToastTheme, { title: string; description: string }> = {
+  info: { title: "Information", description: "This is an informational notification." },
+  success: { title: "Success!", description: "Your action completed successfully." },
+  warning: { title: "Warning", description: "Please review this before continuing." },
+  error: { title: "Error", description: "Something went wrong. Please try again." },
+};
+
+export default {
+  title: "Atoms/DisplayToastProvider",
+  component: DisplayToastProvider,
+  argTypes: {
+    position: {
+      control: { type: "select" },
+      options: ["top", "bottom"],
+      description: "Vertical position of toasts",
+      table: { category: "Provider" },
+    },
+    alignment: {
+      control: { type: "select" },
+      options: ["left", "center", "right"],
+      description: "Horizontal alignment of toasts",
+      table: { category: "Provider" },
+    },
+    fullWidth: {
+      control: "boolean",
+      description: "Toasts span full viewport width",
+      table: { category: "Provider" },
+    },
+    maxVisible: {
+      control: { type: "number", min: 1, max: 5 },
+      description: "Max toasts shown simultaneously",
+      table: { category: "Provider" },
+    },
+    theme: {
+      control: { type: "select" },
+      options: ["info", "success", "warning", "error"],
+      description: "Theme for triggered toast",
+      table: { category: "Toast" },
+    },
+    autoDismiss: {
+      control: "boolean",
+      description: "Auto-dismiss triggered toast",
+      table: { category: "Toast" },
+    },
+    duration: {
+      control: { type: "range", min: 1000, max: 10000, step: 500 },
+      description: "Auto-dismiss duration in ms",
+      table: { category: "Toast" },
+    },
+  },
+  args: {
+    position: "top",
+    alignment: "right",
+    fullWidth: false,
+    maxVisible: 1,
+    theme: "info",
+    autoDismiss: true,
+    duration: 4000,
+  },
+} as Meta<StoryArgs>;
+
+const Template: StoryFn<StoryArgs> = (args) => ({
+  components: { DisplayToastProvider },
+  setup() {
+    const { show, clear } = useToastQueue();
+
+    const triggerToast = () => {
+      show({
+        appearance: { theme: args.theme },
+        behavior: { autoDismiss: args.autoDismiss, duration: args.duration },
+        content: messages[args.theme],
+      });
+    };
+
+    const queueAll = () => {
+      themes.forEach((theme) => {
+        show({
+          appearance: { theme },
+          behavior: { autoDismiss: args.autoDismiss, duration: args.duration },
+          content: messages[theme],
+        });
+      });
+    };
+
+    return { args, triggerToast, queueAll, clear };
+  },
+  template: `
+    <div style="padding: 2rem; min-height: 200px;">
+      <div style="display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1rem;">
+        <button @click="triggerToast" style="padding: 0.6rem 1.4rem; cursor: pointer; border: 1px solid #ccc; border-radius: 4px;">Trigger Toast</button>
+        <button @click="queueAll" style="padding: 0.6rem 1.4rem; cursor: pointer; border: 1px solid #ccc; border-radius: 4px;">Queue All Themes</button>
+        <button @click="clear" style="padding: 0.6rem 1.4rem; cursor: pointer; border: 1px solid #ccc; border-radius: 4px;">Clear Queue</button>
+      </div>
+      <DisplayToastProvider
+        :position="args.position"
+        :alignment="args.alignment"
+        :full-width="args.fullWidth"
+        :max-visible="args.maxVisible"
+      />
+    </div>
+  `,
+});
+
+export const Default = Template.bind({});
+
+export const BottomLeft = Template.bind({});
+BottomLeft.args = {
+  position: "bottom",
+  alignment: "left",
+  theme: "success",
+  autoDismiss: false,
+};
+
+export const Stacked = Template.bind({});
+Stacked.args = {
+  maxVisible: 3,
+  autoDismiss: false,
+};
+
+export const FullWidth = Template.bind({});
+FullWidth.args = {
+  fullWidth: true,
+  theme: "warning",
+  autoDismiss: false,
+};

--- a/app/components/01.atoms/toast/tests/DisplayToastProvider.spec.ts
+++ b/app/components/01.atoms/toast/tests/DisplayToastProvider.spec.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi } from "vitest";
+import { nextTick } from "vue";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import DisplayToastProvider from "../DisplayToastProvider.vue";
+import { useToastQueue } from "~/composables/useToastQueue";
+
+function item() {
+  return document.querySelector(".display-toast-provider-item");
+}
+
+function items() {
+  return document.querySelectorAll(".display-toast-provider-item");
+}
+
+function provider() {
+  return document.querySelector(".display-toast-provider");
+}
+
+describe("DisplayToastProvider", () => {
+  const { show, clear } = useToastQueue();
+
+  beforeEach(() => {
+    clear();
+  });
+
+  afterEach(() => {
+    clear();
+    document.body.innerHTML = "";
+  });
+
+  // ─── Mount ────────────────────────────────────────────────────────────────
+
+  it("mounts without error", async () => {
+    const wrapper = await mountSuspended(DisplayToastProvider);
+    expect(wrapper.vm).toBeTruthy();
+  });
+
+  it("renders the provider container", async () => {
+    await mountSuspended(DisplayToastProvider);
+    expect(provider()).not.toBeNull();
+  });
+
+  // ─── Empty state ──────────────────────────────────────────────────────────
+
+  it("renders no items when queue is empty", async () => {
+    await mountSuspended(DisplayToastProvider);
+    expect(items().length).toBe(0);
+  });
+
+  // ─── Show / queue ─────────────────────────────────────────────────────────
+
+  it("promotes a pending entry to visible on show()", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({ content: { text: "Hello" } });
+    await nextTick();
+    expect(items().length).toBe(1);
+  });
+
+  it("renders the toast message text", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({ content: { text: "Toast message" } });
+    await nextTick();
+    expect(document.querySelector(".toast-message")!.textContent).toContain("Toast message");
+  });
+
+  it("renders the toast title", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({ content: { title: "My Title" } });
+    await nextTick();
+    expect(document.querySelector("[data-test-id='toast-title']")!.textContent).toContain("My Title");
+  });
+
+  it("renders the toast description", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({ content: { description: "My description" } });
+    await nextTick();
+    expect(document.querySelector("[data-test-id='toast-description']")!.textContent).toContain("My description");
+  });
+
+  // ─── data-theme ───────────────────────────────────────────────────────────
+
+  it.each(["info", "success", "warning", "error"] as const)(
+    "sets data-theme='%s' from config",
+    async (theme) => {
+      await mountSuspended(DisplayToastProvider);
+      show({ appearance: { theme } });
+      await nextTick();
+      expect(item()!.getAttribute("data-theme")).toBe(theme);
+    }
+  );
+
+  it("defaults to data-theme='info'", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({});
+    await nextTick();
+    expect(item()!.getAttribute("data-theme")).toBe("info");
+  });
+
+  // ─── ARIA ─────────────────────────────────────────────────────────────────
+
+  it.each([
+    { theme: "info" as const, role: "status", live: "polite" },
+    { theme: "success" as const, role: "status", live: "polite" },
+    { theme: "warning" as const, role: "alert", live: "assertive" },
+    { theme: "error" as const, role: "alert", live: "assertive" },
+  ])("sets role=$role and aria-live=$live for theme='$theme'", async ({ theme, role, live }) => {
+    await mountSuspended(DisplayToastProvider);
+    show({ appearance: { theme } });
+    await nextTick();
+    expect(item()!.getAttribute("role")).toBe(role);
+    expect(item()!.getAttribute("aria-live")).toBe(live);
+  });
+
+  it("sets aria-describedby on each item", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({});
+    await nextTick();
+    expect(item()!.getAttribute("aria-describedby")).not.toBeNull();
+  });
+
+  it("sets tabindex='0' on each item", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({});
+    await nextTick();
+    expect(item()!.getAttribute("tabindex")).toBe("0");
+  });
+
+  // ─── Position / alignment classes ────────────────────────────────────────
+
+  it.each(["top", "bottom"] as const)("applies %s class to provider", async (position) => {
+    await mountSuspended(DisplayToastProvider, { props: { position } });
+    expect(provider()!.classList).toContain(position);
+  });
+
+  it.each(["left", "center", "right"] as const)(
+    "applies %s alignment class to provider",
+    async (alignment) => {
+      await mountSuspended(DisplayToastProvider, { props: { alignment } });
+      expect(provider()!.classList).toContain(alignment);
+    }
+  );
+
+  it("applies full-width class when fullWidth is true", async () => {
+    await mountSuspended(DisplayToastProvider, { props: { fullWidth: true } });
+    expect(provider()!.classList).toContain("full-width");
+  });
+
+  it("does not apply alignment class when fullWidth is true", async () => {
+    await mountSuspended(DisplayToastProvider, { props: { fullWidth: true, alignment: "left" } });
+    expect(provider()!.classList).not.toContain("left");
+  });
+
+  // ─── maxVisible ───────────────────────────────────────────────────────────
+
+  it("shows only one item at a time when maxVisible=1", async () => {
+    await mountSuspended(DisplayToastProvider, { props: { maxVisible: 1 } });
+    show({ content: { text: "First" } });
+    show({ content: { text: "Second" } });
+    await nextTick();
+    expect(items().length).toBe(1);
+    expect(document.querySelector(".toast-message")!.textContent).toContain("First");
+  });
+
+  it("shows up to maxVisible items simultaneously", async () => {
+    await mountSuspended(DisplayToastProvider, { props: { maxVisible: 2 } });
+    show({ content: { text: "First" } });
+    show({ content: { text: "Second" } });
+    show({ content: { text: "Third" } });
+    await nextTick();
+    expect(items().length).toBe(2);
+  });
+
+  // ─── Dismiss ──────────────────────────────────────────────────────────────
+
+  it("removes item when close button is clicked", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({ behavior: { autoDismiss: false } });
+    await nextTick();
+    (document.querySelector(".toast-action button") as HTMLElement).click();
+    await nextTick();
+    expect(items().length).toBe(0);
+  });
+
+  it("removes item when Escape is pressed", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({ behavior: { autoDismiss: false } });
+    await nextTick();
+    item()!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await nextTick();
+    expect(items().length).toBe(0);
+  });
+
+  // ─── Auto-dismiss timer ───────────────────────────────────────────────────
+
+  it("auto-dismisses after duration", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({ behavior: { autoDismiss: true, duration: 3000 } });
+    await nextTick();
+    expect(items().length).toBe(1);
+    vi.advanceTimersByTime(3000);
+    await nextTick();
+    expect(items().length).toBe(0);
+  });
+
+  it("does not auto-dismiss when autoDismiss is false", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({ behavior: { autoDismiss: false } });
+    await nextTick();
+    vi.advanceTimersByTime(10000);
+    await nextTick();
+    expect(items().length).toBe(1);
+  });
+
+  // ─── Queue progression ────────────────────────────────────────────────────
+
+  it("promotes next pending entry after current is dismissed", async () => {
+    await mountSuspended(DisplayToastProvider, { props: { maxVisible: 1 } });
+    show({ content: { text: "First" }, behavior: { autoDismiss: false } });
+    show({ content: { text: "Second" }, behavior: { autoDismiss: false } });
+    await nextTick();
+    expect(document.querySelector(".toast-message")!.textContent).toContain("First");
+
+    item()!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await nextTick();
+    expect(document.querySelector(".toast-message")!.textContent).toContain("Second");
+  });
+
+  // ─── Progress bar ─────────────────────────────────────────────────────────
+
+  it("renders progress bar when autoDismiss is true", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({ behavior: { autoDismiss: true } });
+    await nextTick();
+    expect(document.querySelector(".display-toast-provider-progress")).not.toBeNull();
+  });
+
+  it("does not render progress bar when autoDismiss is false", async () => {
+    await mountSuspended(DisplayToastProvider);
+    show({ behavior: { autoDismiss: false } });
+    await nextTick();
+    expect(document.querySelector(".display-toast-provider-progress")).toBeNull();
+  });
+
+  // ─── clear() ─────────────────────────────────────────────────────────────
+
+  it("removes all items on clear()", async () => {
+    const { clear: clearQueue } = useToastQueue();
+    await mountSuspended(DisplayToastProvider, { props: { maxVisible: 3 } });
+    show({});
+    show({});
+    await nextTick();
+    clearQueue();
+    await nextTick();
+    expect(items().length).toBe(0);
+  });
+});

--- a/app/composables/useToastQueue.ts
+++ b/app/composables/useToastQueue.ts
@@ -1,0 +1,32 @@
+import type { DisplayToastConfig, ToastQueueEntry } from "~/types/components";
+
+const _queue = ref<ToastQueueEntry[]>([]);
+
+export function useToastQueue() {
+  const show = (config: DisplayToastConfig): string => {
+    const id = `toast-${crypto.randomUUID()}`;
+    _queue.value = [..._queue.value, { id, config, status: "pending" }];
+    return id;
+  };
+
+  const promote = (id: string) => {
+    const entry = _queue.value.find((e) => e.id === id);
+    if (entry) entry.status = "visible";
+  };
+
+  const dismiss = (id: string) => {
+    _queue.value = _queue.value.filter((e) => e.id !== id);
+  };
+
+  const clear = () => {
+    _queue.value = [];
+  };
+
+  return {
+    queue: readonly(_queue),
+    show,
+    promote,
+    dismiss,
+    clear,
+  };
+}

--- a/app/composables/useToastQueue.ts
+++ b/app/composables/useToastQueue.ts
@@ -2,20 +2,20 @@ import type { DisplayToastConfig, ToastQueueEntry } from "~/types/components";
 
 const _queue = ref<ToastQueueEntry[]>([]);
 
+const _promote = (id: string) => {
+  const entry = _queue.value.find((e) => e.id === id);
+  if (entry) entry.status = "visible";
+};
+
+const _dismiss = (id: string) => {
+  _queue.value = _queue.value.filter((e) => e.id !== id);
+};
+
 export function useToastQueue() {
   const show = (config: DisplayToastConfig): string => {
     const id = `toast-${crypto.randomUUID()}`;
     _queue.value = [..._queue.value, { id, config, status: "pending" }];
     return id;
-  };
-
-  const promote = (id: string) => {
-    const entry = _queue.value.find((e) => e.id === id);
-    if (entry) entry.status = "visible";
-  };
-
-  const dismiss = (id: string) => {
-    _queue.value = _queue.value.filter((e) => e.id !== id);
   };
 
   const clear = () => {
@@ -25,8 +25,15 @@ export function useToastQueue() {
   return {
     queue: readonly(_queue),
     show,
-    promote,
-    dismiss,
+    dismiss: _dismiss,
     clear,
+  };
+}
+
+export function useToastQueueProvider() {
+  return {
+    queue: readonly(_queue),
+    promote: _promote,
+    dismiss: _dismiss,
   };
 }

--- a/app/pages/ui/display-toast.vue
+++ b/app/pages/ui/display-toast.vue
@@ -195,7 +195,7 @@ const queueMultiple = () => {
 };
 </script>
 
-<style scoped lang="css">
+<style lang="css">
 .demo-buttons {
   display: flex;
   flex-wrap: wrap;

--- a/app/pages/ui/display-toast.vue
+++ b/app/pages/ui/display-toast.vue
@@ -2,331 +2,293 @@
   <div>
     <NuxtLayout name="default">
       <template #layout-content>
-        <PageRow tag="div" variant="full" :style-class-passthrough="['mbe-20', 'p-20']">
-          <h2 class="page-heading-2">DisplayToast Component</h2>
-          <HeaderBlock :tag-level="3" :class-level="3" :style-class-passthrough="['mbe-10']">
-            Toast notification component (HeaderBlock)
-          </HeaderBlock>
-          <p class="page-body-normal">Trigger default toast with manual dismiss</p>
+        <PageRow tag="div" variant="content" :style-class-passthrough="['mbe-20', 'p-20']">
+          <h2 class="page-heading-2">DisplayToast / DisplayToastProvider</h2>
+
+          <div v-if="isDev" class="qa-panel">
+            <details class="qa-panel__details">
+              <summary class="qa-panel__summary">
+                <span class="qa-panel__title">QA — DisplayToastProvider</span>
+                <code class="qa-panel__status">
+                  {{ qaTheme }} · {{ qaPosition }}-{{ qaAlignment }} ·
+                  {{ qaAutoDismiss ? `auto ${qaDuration}ms` : "manual" }} · max:{{ qaMaxVisible }}
+                </code>
+              </summary>
+              <div class="qa-panel__body">
+                <div class="qa-panel__group">
+                  <span class="qa-panel__label">Theme</span>
+                  <div class="qa-panel__chips">
+                    <button
+                      v-for="opt in themes"
+                      :key="opt"
+                      class="qa-panel__chip"
+                      :class="{ 'is-active': qaTheme === opt }"
+                      @click="qaTheme = opt"
+                    >
+                      {{ opt }}
+                    </button>
+                  </div>
+                </div>
+
+                <div class="qa-panel__group">
+                  <span class="qa-panel__label">Position</span>
+                  <div class="qa-panel__chips">
+                    <button
+                      v-for="opt in positions"
+                      :key="opt"
+                      class="qa-panel__chip"
+                      :class="{ 'is-active': qaPosition === opt }"
+                      @click="qaPosition = opt"
+                    >
+                      {{ opt }}
+                    </button>
+                  </div>
+                </div>
+
+                <div class="qa-panel__group">
+                  <span class="qa-panel__label">Alignment</span>
+                  <div class="qa-panel__chips">
+                    <button
+                      v-for="opt in alignments"
+                      :key="opt"
+                      class="qa-panel__chip"
+                      :class="{ 'is-active': qaAlignment === opt }"
+                      @click="qaAlignment = opt"
+                    >
+                      {{ opt }}
+                    </button>
+                  </div>
+                </div>
+
+                <div class="qa-panel__group">
+                  <span class="qa-panel__label">Full Width</span>
+                  <div class="qa-panel__chips">
+                    <button
+                      v-for="opt in [true, false]"
+                      :key="String(opt)"
+                      class="qa-panel__chip"
+                      :class="{ 'is-active': qaFullWidth === opt }"
+                      @click="qaFullWidth = opt"
+                    >
+                      {{ opt ? "yes" : "no" }}
+                    </button>
+                  </div>
+                </div>
+
+                <div class="qa-panel__group">
+                  <span class="qa-panel__label">Auto Dismiss</span>
+                  <div class="qa-panel__chips">
+                    <button
+                      v-for="opt in [true, false]"
+                      :key="String(opt)"
+                      class="qa-panel__chip"
+                      :class="{ 'is-active': qaAutoDismiss === opt }"
+                      @click="qaAutoDismiss = opt"
+                    >
+                      {{ opt ? "yes" : "no" }}
+                    </button>
+                  </div>
+                </div>
+
+                <div class="qa-panel__group">
+                  <span class="qa-panel__label">Duration</span>
+                  <div class="qa-panel__chips">
+                    <button
+                      v-for="opt in durations"
+                      :key="opt"
+                      class="qa-panel__chip"
+                      :class="{ 'is-active': qaDuration === opt }"
+                      @click="qaDuration = opt"
+                    >
+                      {{ opt }}ms
+                    </button>
+                  </div>
+                </div>
+
+                <div class="qa-panel__group">
+                  <span class="qa-panel__label">Max Visible</span>
+                  <div class="qa-panel__chips">
+                    <button
+                      v-for="opt in [1, 2, 3]"
+                      :key="opt"
+                      class="qa-panel__chip"
+                      :class="{ 'is-active': qaMaxVisible === opt }"
+                      @click="qaMaxVisible = opt"
+                    >
+                      {{ opt }}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </details>
+          </div>
+
           <form class="form-wrapper">
-            <p>
-              <InputButtonCore
-                ref="firstToastButton"
-                :readonly="firstToastActive"
-                button-text="Trigger First Toast (current value: {{ firstToastActive }})"
-                theme="default"
-                :style-class-passthrough="['mbe-10']"
-                @click.prevent="triggerFirstToast()"
-              />
-            </p>
-            <hr class="mbe-20" />
-            <p class="page-body-normal">Trigger ERROR prompt as toast with auto dismiss</p>
-            <p>
-              <InputButtonCore
-                ref="secondToastButton"
-                :readonly="secondToastActive"
-                button-text="Trigger Second Toast (current value: {{ secondToastActive }})"
-                theme="default"
-                :style-class-passthrough="['mbe-10']"
-                @click.prevent="triggerSecondToast()"
-              />
-            </p>
-            <hr class="mbe-20" />
-            <p class="page-body-normal">Trigger SUCCESS prompt as toast with manual dismiss</p>
-            <p>
-              <InputButtonCore
-                ref="thirdToastButton"
-                :readonly="thirdToastActive"
-                button-text="Trigger Third Toast (current value: {{ thirdToastActive }})"
-                theme="default"
-                :style-class-passthrough="['mbe-10']"
-                @click.prevent="triggerThirdToast()"
-              />
-            </p>
-            <hr class="mbe-20" />
-            <p class="page-body-normal">Trigger INFO prompt as toast with auto dismiss (full-width)</p>
-            <p>
-              <InputButtonCore
-                ref="fourthToastButton"
-                :readonly="fourthToastActive"
-                button-text="Trigger Fourth Toast (current value: {{ fourthToastActive }})"
-                theme="default"
-                :style-class-passthrough="['mbe-10']"
-                @click.prevent="triggerFourthToast()"
-              />
-            </p>
-            <hr class="mbe-20" />
-            <p class="page-body-normal">New config-based positioning examples:</p>
-            <div class="button-grid">
-              <InputButtonCore
-                ref="bottomLeftToastButton"
-                :readonly="bottomLeftToastActive"
-                button-text="Bottom Left Toast"
-                theme="default"
-                @click.prevent="triggerBottomLeftToast()"
-              />
-              <InputButtonCore
-                ref="bottomCenterToastButton"
-                :readonly="bottomCenterToastActive"
-                button-text="Bottom Center Toast"
-                theme="default"
-                @click.prevent="triggerBottomCenterToast()"
-              />
-              <InputButtonCore
-                ref="customIconToastButton"
-                :readonly="customIconToastActive"
-                button-text="Custom Icon Toast"
-                theme="default"
-                @click.prevent="triggerCustomIconToast()"
-              />
+            <div class="demo-buttons">
+              <InputButtonCore button-text="Trigger Toast" theme="default" @click.prevent="triggerToast" />
+              <InputButtonCore button-text="Queue Multiple" theme="default" @click.prevent="queueMultiple" />
             </div>
-            <hr class="mbe-20" />
-            <p class="page-body-normal">Toast with title and content slots:</p>
-            <p>
-              <InputButtonCore
-                ref="slottedToastButton"
-                :readonly="slottedToastActive"
-                button-text="Trigger Slotted Toast (current value: {{ slottedToastActive }})"
-                theme="default"
-                :style-class-passthrough="['mbe-10']"
-                @click.prevent="triggerSlottedToast()"
-              />
-            </p>
           </form>
         </PageRow>
 
-        <DisplayToast
-          v-model="firstToastActive"
-          :config="{
-            appearance: { theme: 'warning', position: 'top', alignment: 'right' },
-            behavior: { autoDismiss: false, returnFocusTo: firstToastButton },
-            content: {
-              title: 'Warning Alert',
-              description: 'This is a toast notification message with structured content.',
-            },
-          }"
+        <DisplayToastProvider
+          :position="qaPosition"
+          :alignment="qaAlignment"
+          :full-width="qaFullWidth"
+          :max-visible="qaMaxVisible"
         />
-
-        <DisplayToast
-          v-model="secondToastActive"
-          :config="{
-            appearance: { theme: 'error', position: 'top', alignment: 'right' },
-            behavior: { returnFocusTo: secondToastButton },
-          }"
-        >
-          <DisplayPrompt
-            v-model="secondToastActive"
-            theme="error"
-            :dismissible="false"
-            :style-class-passthrough="['dark', 'outlined']"
-          >
-            <template #customDecoratorIcon>
-              <Icon name="akar-icons:info" class="icon" />
-            </template>
-            <template #title>Info Prompt Title with content (Dismissable)</template>
-            <template #content>This is prompt content, it can contain html or plain text.</template>
-          </DisplayPrompt>
-        </DisplayToast>
-
-        <DisplayToast
-          v-model="thirdToastActive"
-          :config="{
-            appearance: { theme: 'success', position: 'top', alignment: 'right' },
-            behavior: { autoDismiss: false, returnFocusTo: thirdToastButton },
-          }"
-        >
-          <DisplayPrompt
-            v-model="thirdToastActive"
-            theme="success"
-            :dismissible="true"
-            :style-class-passthrough="['dark', 'outlined']"
-            :use-auto-focus="true"
-          >
-            <template #customDecoratorIcon>
-              <Icon name="akar-icons:info" class="icon" />
-            </template>
-            <template #title>Success Prompt Title with content (Dismissable)</template>
-            <template #content>This is prompt content, it can contain html or plain text.</template>
-            <template #customCloseIcon>
-              <Icon name="material-symbols:close-small" class="icon" />
-            </template>
-            <template #customTitle>Dismiss</template>
-          </DisplayPrompt>
-        </DisplayToast>
-
-        <DisplayToast
-          v-model="fourthToastActive"
-          :config="{
-            appearance: { theme: 'info', position: 'top', fullWidth: true },
-            behavior: { returnFocusTo: fourthToastButton },
-          }"
-        >
-          <DisplayPrompt
-            v-model="fourthToastActive"
-            theme="info"
-            :dismissible="false"
-            :style-class-passthrough="['dark', 'outlined']"
-          >
-            <template #title>Warning Prompt Title with content (Auto Dismiss)</template>
-            <template #content>This is prompt content, it can contain html or plain text.</template>
-            <template #customCloseIcon>
-              <Icon name="material-symbols:close-small" class="icon" />
-            </template>
-            <template #customTitle>Dismiss</template>
-          </DisplayPrompt>
-        </DisplayToast>
-
-        <DisplayToast
-          v-model="bottomLeftToastActive"
-          :config="{
-            appearance: { theme: 'primary', position: 'bottom', alignment: 'left' },
-            behavior: { autoDismiss: true, duration: 3000, returnFocusTo: bottomLeftToastButton },
-            content: {
-              title: 'Warning Alert',
-              description: 'This is a toast notification message with structured content.',
-            },
-          }"
-        />
-
-        <DisplayToast
-          v-model="bottomCenterToastActive"
-          :config="{
-            appearance: { theme: 'secondary', position: 'bottom', alignment: 'center' },
-            behavior: { autoDismiss: true, duration: 4000, returnFocusTo: bottomCenterToastButton },
-            content: {
-              title: 'Warning Alert',
-              description: 'This is a toast notification message with structured content.',
-            },
-          }"
-        />
-
-        <DisplayToast
-          v-model="customIconToastActive"
-          :config="{
-            appearance: { theme: 'error', position: 'top', alignment: 'left' },
-            behavior: { autoDismiss: false, returnFocusTo: customIconToastButton },
-            content: {
-              title: 'Warning Alert',
-              description: 'This is a toast notification message with structured content.',
-            },
-          }"
-        />
-
-        <DisplayToast
-          v-model="slottedToastActive"
-          :config="{
-            appearance: { theme: 'info', position: 'top', alignment: 'right' },
-            behavior: { autoDismiss: false, returnFocusTo: slottedToastButton },
-          }"
-        >
-          <template #title>
-            <strong>New Feature Available!</strong>
-          </template>
-          <template #description>
-            You can now use title and content slots to create more structured toast notifications with better typography
-            and layout.
-          </template>
-        </DisplayToast>
       </template>
     </NuxtLayout>
   </div>
 </template>
 
 <script setup lang="ts">
-/**
- * DisplayToast Playground - Updated to use new config-based props system
- *
- * This playground demonstrates:
- * 1. Legacy examples converted to new config structure
- * 2. New positioning capabilities (bottom left, bottom center)
- * 3. Custom icon support through config
- * 4. Different behavior configurations (autoDismiss, duration)
- * 5. Return focus functionality for accessibility
- *
- * The new config system groups props into logical sections:
- * - appearance: theme, position, alignment, fullWidth
- * - behavior: autoDismiss, duration, revealDuration, returnFocusTo
- * - content: text, customIcon
- *
- * The returnFocusTo property accepts an HTMLElement or ComponentPublicInstance
- * and will focus that element when the toast is dismissed, improving accessibility.
- */
+import type { DisplayToastTheme, DisplayToastPosition, DisplayToastAlignment } from "~/types/components";
 
-definePageMeta({
-  layout: false,
-});
+definePageMeta({ layout: false });
 
 useHead({
   title: "DisplayToast",
-  meta: [
-    {
-      name: "description",
-      content: "DisplayToast Meta description content",
-    },
-  ],
-  bodyAttrs: {
-    class: "displayToast-page",
-  },
+  meta: [{ name: "description", content: "DisplayToast component demo" }],
+  bodyAttrs: { class: "displayToast-page" },
 });
 
-// Toast state variables
-const firstToastActive = ref(false);
-const secondToastActive = ref(false);
-const thirdToastActive = ref(false);
-const fourthToastActive = ref(false);
-const bottomLeftToastActive = ref(false);
-const bottomCenterToastActive = ref(false);
-const customIconToastActive = ref(false);
-const slottedToastActive = ref(false);
+const isDev = import.meta.dev;
+const { show } = useToastQueue();
 
-// Template refs for focus return
-const firstToastButton = useTemplateRef<HTMLButtonElement>("firstToastButton");
-const secondToastButton = useTemplateRef<HTMLButtonElement>("secondToastButton");
-const thirdToastButton = useTemplateRef<HTMLButtonElement>("thirdToastButton");
-const fourthToastButton = useTemplateRef<HTMLButtonElement>("fourthToastButton");
-const bottomLeftToastButton = useTemplateRef<HTMLButtonElement>("bottomLeftToastButton");
-const bottomCenterToastButton = useTemplateRef<HTMLButtonElement>("bottomCenterToastButton");
-const customIconToastButton = useTemplateRef<HTMLButtonElement>("customIconToastButton");
-const slottedToastButton = useTemplateRef<HTMLButtonElement>("slottedToastButton");
+const themes = ["info", "success", "warning", "error"] as const;
+const positions = ["top", "bottom"] as const;
+const alignments = ["left", "center", "right"] as const;
+const durations = [2000, 3000, 5000, 8000] as const;
 
-const triggerFirstToast = () => {
-  firstToastActive.value = true;
+const qaTheme = ref<DisplayToastTheme>("info");
+const qaPosition = ref<DisplayToastPosition>("top");
+const qaAlignment = ref<DisplayToastAlignment>("right");
+const qaFullWidth = ref(false);
+const qaAutoDismiss = ref(true);
+const qaDuration = ref(5000);
+const qaMaxVisible = ref(1);
+
+const messages: Record<DisplayToastTheme, { title: string; description: string }> = {
+  info: { title: "Information", description: "This is an informational notification." },
+  success: { title: "Success!", description: "Your action completed successfully." },
+  warning: { title: "Warning", description: "Please review this before continuing." },
+  error: { title: "Error", description: "Something went wrong. Please try again." },
 };
 
-const triggerSecondToast = () => {
-  secondToastActive.value = true;
+const triggerToast = () => {
+  show({
+    appearance: { theme: qaTheme.value },
+    behavior: { autoDismiss: qaAutoDismiss.value, duration: qaDuration.value },
+    content: messages[qaTheme.value],
+  });
 };
 
-const triggerThirdToast = () => {
-  thirdToastActive.value = true;
-};
-
-const triggerFourthToast = () => {
-  fourthToastActive.value = true;
-};
-
-const triggerBottomLeftToast = () => {
-  bottomLeftToastActive.value = true;
-};
-
-const triggerBottomCenterToast = () => {
-  bottomCenterToastActive.value = true;
-};
-
-const triggerCustomIconToast = () => {
-  customIconToastActive.value = true;
-};
-
-const triggerSlottedToast = () => {
-  slottedToastActive.value = true;
+const queueMultiple = () => {
+  themes.forEach((theme) => {
+    show({
+      appearance: { theme },
+      behavior: { autoDismiss: qaAutoDismiss.value, duration: qaDuration.value },
+      content: messages[theme],
+    });
+  });
 };
 </script>
 
 <style scoped lang="css">
-.button-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
-  margin-bottom: 1rem;
+.demo-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.2rem;
+}
+
+.displayToast-page {
+  .qa-panel {
+    background: oklch(15% 0 0);
+    color: white;
+    font-size: 1.3rem;
+    margin-block: 1.2rem;
+  }
+
+  .qa-panel__details {
+    padding: 1rem 2rem;
+  }
+
+  .qa-panel__summary {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 1.6rem;
+    list-style: none;
+    user-select: none;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+
+  .qa-panel__title {
+    font-weight: 600;
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .qa-panel__status {
+    font-family: monospace;
+    font-size: 1.2rem;
+    background: oklch(0% 0 0 / 0.3);
+    padding: 0.2rem 0.8rem;
+    border-radius: 0.4rem;
+    user-select: text;
+    cursor: text;
+  }
+
+  .qa-panel__body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2.4rem;
+    padding-block: 1.2rem 0.4rem;
+  }
+
+  .qa-panel__group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .qa-panel__label {
+    font-size: 1.1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.55;
+  }
+
+  .qa-panel__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .qa-panel__chip {
+    font-family: monospace;
+    font-size: 1.2rem;
+    color: white;
+    background: oklch(0% 0 0 / 0.25);
+    border: 1px solid oklch(100% 0 0 / 0.18);
+    padding: 0.3rem 1rem;
+    border-radius: 0.4rem;
+    cursor: pointer;
+    transition: background 0.15s;
+
+    &:hover {
+      background: oklch(0% 0 0 / 0.4);
+    }
+
+    &.is-active {
+      background: oklch(55% 0.18 240);
+      border-color: oklch(55% 0.18 240);
+    }
+  }
 }
 </style>

--- a/app/types/components/display-toast.d.ts
+++ b/app/types/components/display-toast.d.ts
@@ -38,6 +38,14 @@ export interface DisplayToastProps {
   styleClassPassthrough?: string | string[]
 }
 
+export type ToastQueueStatus = "pending" | "visible"
+
+export interface ToastQueueEntry {
+  id: string
+  config: DisplayToastConfig
+  status: ToastQueueStatus
+}
+
 export interface ToastSlots {
   default?(props?: Record<string, never>): VNode[]
   customToastIcon?(props?: Record<string, never>): VNode[]


### PR DESCRIPTION
## Add app-wide toast queue infrastructure (`DisplayToastProvider` + `useToastQueue`)

### Summary

- **`useToastQueue` composable** — module-level singleton reactive queue (no Pinia). `show()` returns an ID, `dismiss(id)` removes a specific toast, `clear()` flushes all. Uses `crypto.randomUUID()` with a `toast-` prefix for guaranteed unique IDs. The queue is exposed as `readonly` to consumers.

- **`DisplayToastProvider` component** — placed once in the app layout. Consumes the queue and renders visible entries via `Teleport to="body"` + `TransitionGroup`. Supports `position`, `alignment`, `fullWidth`, and `maxVisible` props. Promotes pending entries to visible up to `maxVisible`, starts per-entry auto-dismiss timers, and handles Escape-key and close-button dismissal.

- **Queue-driven stacking** — toasts queue as `pending` and are promoted sequentially as visible slots open. When a visible toast is dismissed, the next pending entry enters immediately.

- **FLIP animation for stack dismissal** — `@before-leave` pins each departing toast's `top`/`width` before it becomes `position: absolute`, removing it from flex flow so remaining toasts FLIP-animate (via `v-move`) into their new positions smoothly rather than snapping. `min-width` is pinned on the container during each leave and released in `@after-leave` to prevent the right-anchored `width: max-content` container from collapsing and causing horizontal jitter.

- **Enter animation fix** — `DisplayToastProvider` now uses explicit `showTop`/`showBottom` keyframes (with `from` states) instead of relying on `v-enter-from` being captured by the animation engine, ensuring the slide-in is always visible.

- **Updated demo page** (`pages/ui/display-toast.vue`) — simplified to two trigger buttons ("Trigger Toast", "Queue Multiple") with a dev-only QA panel for all position/alignment/theme/auto-dismiss/maxVisible controls.

- **New Storybook stories** (`DisplayToastProvider.stories.ts`) — Default, BottomLeft, Stacked (maxVisible: 3), FullWidth stories with grouped arg controls for provider and toast config.

- **35 tests** covering mount, empty state, show/promote, content rendering, data-theme, ARIA roles/live/describedby, tabindex, position/alignment/fullWidth classes, maxVisible gating, close-button dismiss, Escape-key dismiss, auto-dismiss timer, no-auto-dismiss, queue progression, progress bar, and `clear()`.

- **Skills updated** — `display-toast.md` expanded to document both the standalone `DisplayToast` pattern and the new queue-based pattern side-by-side.

### Test plan

- [ ] Trigger a single toast — verify slide-in animation (top and bottom positions)
- [ ] Queue multiple toasts with maxVisible=1 — verify sequential promotion on dismiss
- [ ] Queue multiple with maxVisible=3 — verify up to 3 visible, remaining in queue
- [ ] Dismiss a toast mid-stack — verify remaining toasts FLIP smoothly with no horizontal jitter
- [ ] Dismiss to promote next in queue — verify new toast enters cleanly (no right-edge flash)
- [ ] Verify auto-dismiss timer and progress bar
- [ ] Verify Escape key dismisses focused toast
- [ ] `npm run test:run` — all 35 tests pass
