### PR TITLE
Feature/add app config

### DIFF
--- a/.claude/skills/components/alert-content-inner.md
+++ b/.claude/skills/components/alert-content-inner.md
@@ -1,0 +1,60 @@
+# AlertContentInner
+
+## Overview
+
+Internal molecule used by `AlertContent` and `AlertMaskedContent`, which are in turn used by
+`DisplayToast` and `DisplayPrompt`. Renders the icon, title/body text, and optional dismiss button.
+Because it sits below multiple consumer components, icon customisation here applies everywhere.
+
+**Location**: `app/components/02.molecules/alert-content/AlertContentInner.vue`
+
+## Props
+
+| Prop | Type | Default | Notes |
+|---|---|---|---|
+| `theme` | `SemanticTheme` | — | **Required.** Drives the default icon and `data-theme` (set by parent `AlertContent`). |
+| `customIcon` | `string` | `undefined` | Icon name override passed down from the toast/prompt `config.content.customIcon`. |
+| `dismissible` | `boolean` | `false` | Shows the dismiss button when `true`. |
+| `contentId` | `string` | `undefined` | Sets `id` on `.alert-content-body` for `aria-describedby` wiring. |
+| `ariaLive` | `"polite" \| "assertive" \| "off"` | `undefined` | Sets `aria-live` on `.alert-content-body`. |
+
+## app.config defaults
+
+Icon names — both per-theme and the dismiss button — are configurable globally via `app.config`.
+One change here covers every toast, prompt, and any other component built on `AlertContentInner`.
+
+```ts
+// Consumer's app.config.ts
+export default defineAppConfig({
+  srcdev: {
+    alertContent: {
+      icons: {
+        info: "heroicons:information-circle",
+        success: "heroicons:check-circle",
+        warning: "heroicons:exclamation-triangle",
+        error: "heroicons:x-circle",
+      },
+      dismissIcon: "heroicons:x-mark",
+    },
+  },
+})
+```
+
+Resolution chain: **`customIcon` prop → app.config icons → hardcoded fallback**.
+
+The `dismissIcon` slot (`#dismissIcon` on `AlertContent`) always wins over app.config if provided.
+
+## Slots
+
+| Slot | Description |
+|---|---|
+| `#icon` | Replaces the entire icon region. |
+| `#title` | Title line inside `.alert-content-body`. |
+| `#content` | Body text inside `.alert-content-body`. |
+| `#dismissIcon` | Replaces the dismiss button icon. |
+| `#dismissLabel` | SR-only label for the dismiss button (default: `"Close"`). |
+
+## Notes
+
+- Do not use `AlertContentInner` directly in pages — use `AlertContent` or `AlertMaskedContent` instead.
+- `AlertMaskedContent` wraps `AlertContentInner` with a different background treatment (SVG glass border).

--- a/.claude/skills/components/display-dialog.md
+++ b/.claude/skills/components/display-dialog.md
@@ -20,6 +20,7 @@ open/close state management.
 | `lockViewport` | `boolean` | `true` | Adds/removes `lock` class on `<body>` on mount/close. |
 | `justifyDialog` | `'start' \| 'center' \| 'end'` | `'center'` | Horizontal position of panel within overlay. |
 | `alignDialog` | `'start' \| 'center' \| 'end'` | `'center'` | Vertical position of panel within overlay. |
+| `closeIcon` | `string` | app.config | Icon name for the header close button. Override per-instance or set globally via `app.config`. |
 | `styleClassPassthrough` | `string \| string[]` | `[]` | Extra classes applied to the root `<dialog>` element. |
 
 ## Slots
@@ -104,6 +105,28 @@ are both disabled — the user must act via the footer buttons.
   </template>
 </DisplayDialog>
 ```
+
+## app.config defaults
+
+All props except `dataDialogId` and `styleClassPassthrough` can be set globally via `app.config`.
+The resolution chain is: **explicit prop → app.config → hardcoded fallback**.
+
+```ts
+// app.config.ts in the consumer app
+export default defineAppConfig({
+  srcdev: {
+    displayDialog: {
+      variant: "modal",
+      alignDialog: "end",
+      lockViewport: true,
+      closeIcon: "heroicons:x-mark",
+      theme: "info",
+    },
+  },
+})
+```
+
+Per-instance props always win — app.config only fills in when a prop is absent.
 
 ## CSS token API
 

--- a/.claude/skills/components/display-prompt.md
+++ b/.claude/skills/components/display-prompt.md
@@ -55,6 +55,27 @@ Two modes depending on whether `v-model` is bound:
 The `.closed` class triggers a CSS grid row animation (`grid-template-rows: 1fr → 0fr`) with
 `opacity: 0` and `pointer-events: none`.
 
+## app.config defaults
+
+All props except `styleClassPassthrough` can be set globally so every prompt in the app inherits
+the same defaults without repeating them at each usage site.
+
+```ts
+// Consumer's app.config.ts
+export default defineAppConfig({
+  srcdev: {
+    displayPrompt: {
+      theme: "info",
+      dismissible: true,
+      masked: false,
+      useAutoFocus: false,
+    },
+  },
+})
+```
+
+Resolution chain: **explicit prop → app.config → hardcoded fallback**.
+
 ## Basic usage
 
 ```vue

--- a/.claude/skills/components/display-toast.md
+++ b/.claude/skills/components/display-toast.md
@@ -58,6 +58,25 @@ interface DisplayToastConfig {
 }
 ```
 
+### app.config defaults
+
+`appearance` and `behavior` keys (not `content` — that's per-instance) can be set globally so
+every toast in the app inherits the same defaults without repeating them in every `config` prop.
+
+```ts
+// Consumer's app.config.ts
+export default defineAppConfig({
+  srcdev: {
+    displayToast: {
+      appearance: { theme: "success", position: "bottom", alignment: "left" },
+      behavior: { autoDismiss: true, duration: 4000 },
+    },
+  },
+})
+```
+
+Resolution chain: **`config` prop → app.config → hardcoded fallback**.
+
 ### Slots
 
 | Slot | Description |

--- a/.claude/skills/index.md
+++ b/.claude/skills/index.md
@@ -56,6 +56,7 @@ Each skill is a single markdown file named `<area>-<task>.md`.
 ├── composable-anchor-scroll.md       — useAnchorScroll: smooth anchor scrolling with reduced-motion support, dynamic offset, and TabNavigation integration
 ├── composable-tooltips-guide.md      — useTooltipsGuide: sequential popover guide with auto-start, dismiss-to-advance, manual controls
 └── components/
+    ├── alert-content-inner.md    — AlertContentInner: shared icon/body/dismiss molecule under AlertContent + AlertMaskedContent; app.config icon map (alertContent.icons + dismissIcon) covers all consumers
     ├── accordian-core.md       — AccordianCore indexed dynamic slots (accordian-{n}-summary/icon/content), exclusive-open grouping
     ├── eyebrow-text.md         — EyebrowText props, usage patterns, styling
     ├── hero-text.md            — HeroText props, usage patterns, styling

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ storybook-static/
 # Claude Code settings (both are machine-specific, neither belongs in the repo)
 .claude/settings.json
 .claude/settings.local.json
+# Claude Code session/memory data (machine-specific, generated at runtime)
+.claude/projects/

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,7 +1,36 @@
-import type { SemanticTheme } from "~/types/components";
+import type { SemanticTheme, DisplayPromptTheme, DisplayToastTheme, DisplayToastPosition, DisplayToastAlignment } from "~/types/components";
 
 export default defineAppConfig({
   srcdev: {
+    alertContent: {
+      icons: {
+        info: "akar-icons:info",
+        success: "akar-icons:check",
+        warning: "akar-icons:circle-alert",
+        error: "akar-icons:circle-alert",
+      },
+      dismissIcon: "material-symbols:close",
+    },
+    displayPrompt: {
+      theme: "info" as DisplayPromptTheme,
+      dismissible: false,
+      useAutoFocus: false,
+      masked: false,
+    },
+    displayToast: {
+      appearance: {
+        theme: "info" as DisplayToastTheme,
+        position: "top" as DisplayToastPosition,
+        alignment: "right" as DisplayToastAlignment,
+        fullWidth: false,
+        masked: false,
+      },
+      behavior: {
+        autoDismiss: true,
+        duration: 5000,
+        revealDuration: 550,
+      },
+    },
     displayDialog: {
       variant: "dialog" as "dialog" | "modal" | "confirm" | "alert" | "fullscreen",
       justifyDialog: "center" as "start" | "center" | "end",

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,0 +1,15 @@
+import type { SemanticTheme } from "~/types/components";
+
+export default defineAppConfig({
+  srcdev: {
+    displayDialog: {
+      variant: "dialog" as "dialog" | "modal" | "confirm" | "alert" | "fullscreen",
+      justifyDialog: "center" as "start" | "center" | "end",
+      alignDialog: "center" as "start" | "center" | "end",
+      lockViewport: true,
+      allowContentScroll: false,
+      theme: undefined as SemanticTheme | undefined,
+      closeIcon: "bitcoin-icons:cross-filled",
+    },
+  },
+});

--- a/app/components/01.atoms/display-dialog/DisplayDialog.vue
+++ b/app/components/01.atoms/display-dialog/DisplayDialog.vue
@@ -5,8 +5,8 @@
     :role="isAlert ? 'alertdialog' : undefined"
     :aria-modal="true"
     :aria-labelledby="hasTitle ? dialogTitleId : undefined"
-    :align-dialog
-    :justify-dialog
+    :align-dialog="resolved.alignDialog"
+    :justify-dialog="resolved.justifyDialog"
     :open
     :data-dialog-id="dataDialogId"
   >
@@ -16,8 +16,8 @@
       :click-outside-deactivates="!isAlert"
       @deactivate="closeDialog()"
     >
-      <div class="inner" :class="[variant]">
-        <div class="header" :data-theme="theme">
+      <div class="inner" :class="[resolved.variant]">
+        <div class="header" :data-theme="resolved.theme">
           <div v-if="hasTitle" :id="dialogTitleId" class="col-left">
             <slot name="dialogTitle"></slot>
           </div>
@@ -28,7 +28,7 @@
               class="display-dialog-close"
               @click.prevent="closeDialog()"
             >
-              <Icon name="bitcoin-icons:cross-filled" class="icon" />
+              <Icon :name="resolved.closeIcon" class="icon" />
               <span class="sr-only">Close</span>
             </button>
           </div>
@@ -36,8 +36,8 @@
         <div
           v-if="hasContent"
           class="dialog-content"
-          :class="[{ 'allow-content-scroll': allowContentScroll }]"
-          :tabindex="allowContentScroll ? 0 : undefined"
+          :class="[{ 'allow-content-scroll': resolved.allowContentScroll }]"
+          :tabindex="resolved.allowContentScroll ? 0 : undefined"
         >
           <slot name="dialogContent"></slot>
         </div>
@@ -67,17 +67,32 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   styleClassPassthrough: () => [],
-  variant: "dialog",
-  justifyDialog: "center",
-  alignDialog: "center",
-  lockViewport: true,
-  allowContentScroll: false,
+  variant: undefined,
+  justifyDialog: undefined,
+  alignDialog: undefined,
+  lockViewport: undefined,
+  allowContentScroll: undefined,
   theme: undefined,
+});
+
+const appConfig = useAppConfig();
+
+const resolved = computed(() => {
+  const config = appConfig.srcdev?.displayDialog;
+  return {
+    variant: props.variant ?? config?.variant ?? "dialog",
+    justifyDialog: props.justifyDialog ?? config?.justifyDialog ?? "center",
+    alignDialog: props.alignDialog ?? config?.alignDialog ?? "center",
+    lockViewport: props.lockViewport ?? config?.lockViewport ?? true,
+    allowContentScroll: props.allowContentScroll ?? config?.allowContentScroll ?? false,
+    theme: props.theme ?? config?.theme,
+    closeIcon: config?.closeIcon ?? "bitcoin-icons:cross-filled",
+  } as const;
 });
 
 const { elementClasses } = useStyleClassPassthrough(props.styleClassPassthrough);
 
-const isAlert = computed(() => props.variant === "alert");
+const isAlert = computed(() => resolved.value.variant === "alert");
 const dialogTitleId = useId();
 
 const open = defineModel<boolean>();
@@ -95,7 +110,7 @@ const { lock, unlock } = useBodyLock();
 let hasLocked = false;
 
 onMounted(() => {
-  if (props.lockViewport) {
+  if (resolved.value.lockViewport) {
     lock();
     hasLocked = true;
   }

--- a/app/components/01.atoms/display-dialog/DisplayDialog.vue
+++ b/app/components/01.atoms/display-dialog/DisplayDialog.vue
@@ -63,6 +63,7 @@ interface Props {
   allowContentScroll?: boolean;
   dataDialogId: string;
   theme?: SemanticTheme;
+  closeIcon?: string;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -73,6 +74,7 @@ const props = withDefaults(defineProps<Props>(), {
   lockViewport: undefined,
   allowContentScroll: undefined,
   theme: undefined,
+  closeIcon: undefined,
 });
 
 const appConfig = useAppConfig();
@@ -86,7 +88,7 @@ const resolved = computed(() => {
     lockViewport: props.lockViewport ?? config?.lockViewport ?? true,
     allowContentScroll: props.allowContentScroll ?? config?.allowContentScroll ?? false,
     theme: props.theme ?? config?.theme,
-    closeIcon: config?.closeIcon ?? "bitcoin-icons:cross-filled",
+    closeIcon: props.closeIcon ?? config?.closeIcon ?? "bitcoin-icons:cross-filled",
   } as const;
 });
 

--- a/app/components/01.atoms/display-dialog/tests/DisplayDialog.spec.ts
+++ b/app/components/01.atoms/display-dialog/tests/DisplayDialog.spec.ts
@@ -5,7 +5,7 @@ import type { SemanticTheme } from "~/types/components";
 
 const { useAppConfigMock } = vi.hoisted(() => ({
   // icon: {} is required — @nuxt/icon reads useAppConfig().icon.collections internally.
-  useAppConfigMock: vi.fn(() => ({ srcdev: undefined, icon: {} })),
+  useAppConfigMock: vi.fn(() => ({ srcdev: undefined as Record<string, unknown> | undefined, icon: {} as object })),
 }));
 
 mockNuxtImport("useAppConfig", () => useAppConfigMock);
@@ -305,7 +305,7 @@ describe("DisplayDialog", () => {
       wrapper
         .find('[data-test-id="display-dialog-header-close"] .iconify')
         .classes()
-        .find((c) => c !== "iconify" && c !== "icon") ?? "";
+        .find((c: string) => c !== "iconify" && c !== "icon") ?? "";
 
     it("uses hardcoded fallbacks when app.config has no displayDialog key", async () => {
       const wrapper = await mountSuspended(DisplayDialog, {

--- a/app/components/01.atoms/display-dialog/tests/DisplayDialog.spec.ts
+++ b/app/components/01.atoms/display-dialog/tests/DisplayDialog.spec.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
 import DisplayDialog from "../DisplayDialog.vue";
+import type { SemanticTheme } from "~/types/components";
+
+const { useAppConfigMock } = vi.hoisted(() => ({
+  // icon: {} is required — @nuxt/icon reads useAppConfig().icon.collections internally.
+  useAppConfigMock: vi.fn(() => ({ srcdev: undefined, icon: {} })),
+}));
+
+mockNuxtImport("useAppConfig", () => useAppConfigMock);
 
 vi.mock("focus-trap-vue", () => ({
   FocusTrap: {
@@ -277,5 +285,114 @@ describe("DisplayDialog", () => {
     expect(document.body.classList.contains("lock")).toBe(true);
     wrapper1.unmount();
     expect(document.body.classList.contains("lock")).toBe(false);
+  });
+
+  // ─── app.config resolution ────────────────────────────────────────────────
+  // Icon renders as <span class="iconify undefined{name} icon"> in jsdom.
+  // All assertions are DOM-based — setupState is private API in <script setup>.
+
+  describe("app.config resolution", () => {
+    beforeEach(() => {
+      useAppConfigMock.mockReturnValue({ srcdev: undefined, icon: {} });
+    });
+
+    afterEach(() => {
+      document.body.classList.remove("lock");
+      delete document.body.dataset.lockCount;
+    });
+
+    const iconName = (wrapper: Awaited<ReturnType<typeof mountSuspended>>) =>
+      wrapper
+        .find('[data-test-id="display-dialog-header-close"] .iconify')
+        .classes()
+        .find((c) => c !== "iconify" && c !== "icon") ?? "";
+
+    it("uses hardcoded fallbacks when app.config has no displayDialog key", async () => {
+      const wrapper = await mountSuspended(DisplayDialog, {
+        props: { dataDialogId: "test" },
+        slots: { dialogContent: "<p>Content</p>" },
+      });
+      expect(wrapper.find(".inner").classes()).toContain("dialog");
+      expect(wrapper.attributes("align-dialog")).toBe("center");
+      expect(wrapper.attributes("justify-dialog")).toBe("center");
+      expect(document.body.classList.contains("lock")).toBe(true);
+      expect(wrapper.find(".dialog-content").classes()).not.toContain("allow-content-scroll");
+      expect(wrapper.find(".header").attributes("data-theme")).toBeUndefined();
+      expect(iconName(wrapper)).toContain("bitcoin-icons:cross-filled");
+    });
+
+    it("uses app.config values when no props are supplied", async () => {
+      useAppConfigMock.mockReturnValue({
+        icon: {},
+        srcdev: {
+          displayDialog: {
+            variant: "modal",
+            justifyDialog: "start",
+            alignDialog: "end",
+            lockViewport: false,
+            allowContentScroll: true,
+            theme: "info" as SemanticTheme,
+            closeIcon: "heroicons:x-mark",
+          },
+        },
+      });
+      const wrapper = await mountSuspended(DisplayDialog, {
+        props: { dataDialogId: "test" },
+        slots: { dialogContent: "<p>Content</p>" },
+      });
+      expect(wrapper.find(".inner").classes()).toContain("modal");
+      expect(wrapper.attributes("align-dialog")).toBe("end");
+      expect(wrapper.attributes("justify-dialog")).toBe("start");
+      expect(document.body.classList.contains("lock")).toBe(false);
+      expect(wrapper.find(".dialog-content").classes()).toContain("allow-content-scroll");
+      expect(wrapper.find(".header").attributes("data-theme")).toBe("info");
+      expect(iconName(wrapper)).toContain("heroicons:x-mark");
+    });
+
+    it("explicit props take precedence over app.config", async () => {
+      useAppConfigMock.mockReturnValue({
+        icon: {},
+        srcdev: {
+          displayDialog: {
+            variant: "modal",
+            justifyDialog: "start",
+            alignDialog: "end",
+            lockViewport: false,
+            allowContentScroll: true,
+            theme: "info" as SemanticTheme,
+            closeIcon: "heroicons:x-mark",
+          },
+        },
+      });
+      const wrapper = await mountSuspended(DisplayDialog, {
+        props: {
+          dataDialogId: "test",
+          variant: "fullscreen",
+          justifyDialog: "end",
+          alignDialog: "start",
+          lockViewport: true,
+          allowContentScroll: false,
+          theme: "error" as SemanticTheme,
+          closeIcon: "material-symbols:close",
+        },
+        slots: { dialogContent: "<p>Content</p>" },
+      });
+      expect(wrapper.find(".inner").classes()).toContain("fullscreen");
+      expect(wrapper.attributes("align-dialog")).toBe("start");
+      expect(wrapper.attributes("justify-dialog")).toBe("end");
+      expect(document.body.classList.contains("lock")).toBe(true);
+      expect(wrapper.find(".dialog-content").classes()).not.toContain("allow-content-scroll");
+      expect(wrapper.find(".header").attributes("data-theme")).toBe("error");
+      expect(iconName(wrapper)).toContain("material-symbols:close");
+    });
+
+    it("lockViewport:false in app.config skips body lock on mount", async () => {
+      useAppConfigMock.mockReturnValue({
+        icon: {},
+        srcdev: { displayDialog: { lockViewport: false } },
+      });
+      await mountSuspended(DisplayDialog, { props: { dataDialogId: "test" } });
+      expect(document.body.classList.contains("lock")).toBe(false);
+    });
   });
 });

--- a/app/components/01.atoms/display-dialog/tests/__snapshots__/DisplayDialog.spec.ts.snap
+++ b/app/components/01.atoms/display-dialog/tests/__snapshots__/DisplayDialog.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`DisplayDialog > renders correct HTML structure with all slots 1`] = `
       <div id="v-0-0" class="col-left">
         <p>Title</p>
       </div>
-      <div class="col-right"><button data-test-id="display-dialog-header-close" class="display-dialog-close"><span class="iconify i-bitcoin-icons:cross-filled icon" aria-hidden="true"></span><span class="sr-only">Close</span></button></div>
+      <div class="col-right"><button data-test-id="display-dialog-header-close" class="display-dialog-close"><span class="iconify undefinedbitcoin-icons:cross-filled icon"></span><span class="sr-only">Close</span></button></div>
     </div>
     <div class="dialog-content">
       <p>Content</p>

--- a/app/components/01.atoms/prompt/DisplayPrompt.vue
+++ b/app/components/01.atoms/prompt/DisplayPrompt.vue
@@ -3,15 +3,15 @@
     ref="promptElementRef"
     class="display-prompt-core"
     :class="[{ closed: !componentOpen }]"
-    :data-test-id="`display-prompt-core-${theme}`"
+    :data-test-id="`display-prompt-core-${resolved.theme}`"
     tabindex="0"
   >
-    <div class="display-prompt-wrapper" :data-theme="theme" :class="[elementClasses]" data-test-id="display-prompt">
+    <div class="display-prompt-wrapper" :data-theme="resolved.theme" :class="[elementClasses]" data-test-id="display-prompt">
       <component
         :is="contentComponent"
-        :theme="theme"
-        :dismissible="dismissible"
-        :aria-live="useAutoFocus ? 'polite' : undefined"
+        :theme="resolved.theme"
+        :dismissible="resolved.dismissible"
+        :aria-live="resolved.useAutoFocus ? 'polite' : undefined"
         @dismiss="updateComponentState()"
       >
         <template v-if="slots.customDecoratorIcon" #icon>
@@ -48,14 +48,26 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  theme: "info",
-  dismissible: false,
-  useAutoFocus: false,
-  masked: false,
   styleClassPassthrough: () => [],
+  theme: undefined,
+  dismissible: undefined,
+  useAutoFocus: undefined,
+  masked: undefined,
 });
 
-const contentComponent = computed(() => (props.masked ? AlertMaskedContent : AlertContent));
+const appConfig = useAppConfig();
+
+const resolved = computed(() => {
+  const config = appConfig.srcdev?.displayPrompt;
+  return {
+    theme: props.theme ?? config?.theme ?? "info",
+    dismissible: props.dismissible ?? config?.dismissible ?? false,
+    useAutoFocus: props.useAutoFocus ?? config?.useAutoFocus ?? false,
+    masked: props.masked ?? config?.masked ?? false,
+  } as const;
+});
+
+const contentComponent = computed(() => (resolved.value.masked ? AlertMaskedContent : AlertContent));
 
 const slots = useSlots();
 const promptElementRef = useTemplateRef<HTMLElement>("promptElementRef");
@@ -73,7 +85,7 @@ const updateComponentState = () => {
 };
 
 onMounted(async () => {
-  if (props.useAutoFocus && promptElementRef.value) {
+  if (resolved.value.useAutoFocus && promptElementRef.value) {
     promptElementRef.value.focus();
   }
 });

--- a/app/components/01.atoms/prompt/tests/DisplayPrompt.spec.ts
+++ b/app/components/01.atoms/prompt/tests/DisplayPrompt.spec.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { nextTick } from "vue";
-import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
 import DisplayPrompt from "../DisplayPrompt.vue";
+
+const { useAppConfigMock } = vi.hoisted(() => ({
+  // icon: {} is required — @nuxt/icon reads useAppConfig().icon.collections internally.
+  useAppConfigMock: vi.fn(() => ({ srcdev: undefined, icon: {} })),
+}));
+
+mockNuxtImport("useAppConfig", () => useAppConfigMock);
 
 function root(wrapper: Awaited<ReturnType<typeof mountSuspended<typeof DisplayPrompt>>>) {
   return wrapper.find(".display-prompt-core");
@@ -156,5 +163,43 @@ describe("DisplayPrompt", () => {
     });
     expect(wrapper(w).classes()).toContain("dark");
     expect(wrapper(w).classes()).toContain("outlined");
+  });
+
+  // ─── app.config resolution ────────────────────────────────────────────────
+
+  describe("app.config resolution", () => {
+    beforeEach(() => {
+      useAppConfigMock.mockReturnValue({ srcdev: undefined, icon: {} });
+    });
+
+    it("uses hardcoded fallbacks when app.config has no displayPrompt key", async () => {
+      const w = await mountSuspended(DisplayPrompt);
+      expect(wrapper(w).attributes("data-theme")).toBe("info");
+      expect(root(w).attributes("data-test-id")).toBe("display-prompt-core-info");
+      expect(w.find("[data-test-id='alert-dismiss']").exists()).toBe(false);
+    });
+
+    it("uses app.config values when no props are supplied", async () => {
+      useAppConfigMock.mockReturnValue({
+        icon: {},
+        srcdev: { displayPrompt: { theme: "success", dismissible: true } },
+      });
+      const w = await mountSuspended(DisplayPrompt);
+      expect(wrapper(w).attributes("data-theme")).toBe("success");
+      expect(root(w).attributes("data-test-id")).toBe("display-prompt-core-success");
+      expect(w.find("[data-test-id='alert-dismiss']").exists()).toBe(true);
+    });
+
+    it("explicit props take precedence over app.config", async () => {
+      useAppConfigMock.mockReturnValue({
+        icon: {},
+        srcdev: { displayPrompt: { theme: "warning", dismissible: true } },
+      });
+      const w = await mountSuspended(DisplayPrompt, {
+        props: { theme: "error", dismissible: false },
+      });
+      expect(wrapper(w).attributes("data-theme")).toBe("error");
+      expect(w.find("[data-test-id='alert-dismiss']").exists()).toBe(false);
+    });
   });
 });

--- a/app/components/01.atoms/prompt/tests/DisplayPrompt.spec.ts
+++ b/app/components/01.atoms/prompt/tests/DisplayPrompt.spec.ts
@@ -5,7 +5,7 @@ import DisplayPrompt from "../DisplayPrompt.vue";
 
 const { useAppConfigMock } = vi.hoisted(() => ({
   // icon: {} is required — @nuxt/icon reads useAppConfig().icon.collections internally.
-  useAppConfigMock: vi.fn(() => ({ srcdev: undefined, icon: {} })),
+  useAppConfigMock: vi.fn(() => ({ srcdev: undefined as Record<string, unknown> | undefined, icon: {} as object })),
 }));
 
 mockNuxtImport("useAppConfig", () => useAppConfigMock);

--- a/app/components/01.atoms/toast/DisplayToast.vue
+++ b/app/components/01.atoms/toast/DisplayToast.vue
@@ -79,16 +79,19 @@ const slots = defineSlots<ToastSlots>();
 
 const { elementClasses, resetElementClasses } = useStyleClassPassthrough(props.styleClassPassthrough);
 
+const appConfig = useAppConfig();
+
 // Computed properties for accessing config values with defaults
-const theme = computed(() => props.config?.appearance?.theme ?? "info");
-const position = computed(() => props.config?.appearance?.position ?? "top");
-const alignment = computed(() => props.config?.appearance?.alignment ?? "right");
-const fullWidth = computed(() => props.config?.appearance?.fullWidth ?? false);
-const masked = computed(() => props.config?.appearance?.masked ?? false);
+// Resolution chain: prop config → app.config → hardcoded fallback
+const theme = computed(() => props.config?.appearance?.theme ?? appConfig.srcdev?.displayToast?.appearance?.theme ?? "info");
+const position = computed(() => props.config?.appearance?.position ?? appConfig.srcdev?.displayToast?.appearance?.position ?? "top");
+const alignment = computed(() => props.config?.appearance?.alignment ?? appConfig.srcdev?.displayToast?.appearance?.alignment ?? "right");
+const fullWidth = computed(() => props.config?.appearance?.fullWidth ?? appConfig.srcdev?.displayToast?.appearance?.fullWidth ?? false);
+const masked = computed(() => props.config?.appearance?.masked ?? appConfig.srcdev?.displayToast?.appearance?.masked ?? false);
 const contentComponent = computed(() => (masked.value ? AlertMaskedContent : AlertContent));
-const autoDismiss = computed(() => props.config?.behavior?.autoDismiss ?? true);
-const duration = computed(() => props.config?.behavior?.duration ?? 5000);
-const revealDuration = computed(() => props.config?.behavior?.revealDuration ?? 550);
+const autoDismiss = computed(() => props.config?.behavior?.autoDismiss ?? appConfig.srcdev?.displayToast?.behavior?.autoDismiss ?? true);
+const duration = computed(() => props.config?.behavior?.duration ?? appConfig.srcdev?.displayToast?.behavior?.duration ?? 5000);
+const revealDuration = computed(() => props.config?.behavior?.revealDuration ?? appConfig.srcdev?.displayToast?.behavior?.revealDuration ?? 550);
 const returnFocusTo = computed(() => props.config?.behavior?.returnFocusTo ?? null);
 const toastDisplayText = computed(() => props.config?.content?.text ?? "");
 const toastTitle = computed(() => props.config?.content?.title ?? "");

--- a/app/components/01.atoms/toast/DisplayToast.vue
+++ b/app/components/01.atoms/toast/DisplayToast.vue
@@ -41,13 +41,7 @@
 <script setup lang="ts">
 import AlertContent from "~/components/02.molecules/alert-content/AlertContent.vue";
 import AlertMaskedContent from "~/components/02.molecules/alert-masked-content/AlertMaskedContent.vue";
-import type {
-  DisplayToastConfig,
-  DisplayToastTheme,
-  DisplayToastPosition,
-  DisplayToastAlignment,
-  ToastSlots,
-} from "~/types/components";
+import type { DisplayToastConfig, ToastSlots } from "~/types/components";
 
 interface Props {
   config?: DisplayToastConfig;
@@ -55,23 +49,7 @@ interface Props {
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  config: () => ({
-    appearance: {
-      theme: "info" as DisplayToastTheme,
-      position: "top" as DisplayToastPosition,
-      alignment: "right" as DisplayToastAlignment,
-      fullWidth: false,
-    },
-    behavior: {
-      autoDismiss: true,
-      duration: 5000,
-      revealDuration: 550,
-    },
-    content: {
-      text: "",
-      customIcon: undefined,
-    },
-  }),
+  config: undefined,
   styleClassPassthrough: () => [],
 });
 

--- a/app/components/01.atoms/toast/tests/DisplayToast.spec.ts
+++ b/app/components/01.atoms/toast/tests/DisplayToast.spec.ts
@@ -4,7 +4,7 @@ import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
 
 const { useAppConfigMock } = vi.hoisted(() => ({
   // icon: {} is required — @nuxt/icon reads useAppConfig().icon.collections internally.
-  useAppConfigMock: vi.fn(() => ({ srcdev: undefined, icon: {} })),
+  useAppConfigMock: vi.fn(() => ({ srcdev: undefined as Record<string, unknown> | undefined, icon: {} as object })),
 }));
 
 mockNuxtImport("useAppConfig", () => useAppConfigMock);

--- a/app/components/01.atoms/toast/tests/DisplayToast.spec.ts
+++ b/app/components/01.atoms/toast/tests/DisplayToast.spec.ts
@@ -1,6 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { nextTick } from "vue";
-import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
+
+const { useAppConfigMock } = vi.hoisted(() => ({
+  // icon: {} is required — @nuxt/icon reads useAppConfig().icon.collections internally.
+  useAppConfigMock: vi.fn(() => ({ srcdev: undefined, icon: {} })),
+}));
+
+mockNuxtImport("useAppConfig", () => useAppConfigMock);
 import DisplayToast from "../DisplayToast.vue";
 
 // Helper: mount the toast and activate it so the teleported element is in the DOM.
@@ -212,5 +219,48 @@ describe("DisplayToast", () => {
     await mountAndShow({ styleClassPassthrough: ["class-a", "class-b"] });
     expect(toast()!.classList).toContain("class-a");
     expect(toast()!.classList).toContain("class-b");
+  });
+
+  // ─── app.config resolution ────────────────────────────────────────────────
+  // Combines mockNuxtImport (#imports path) + vi.stubGlobal (global path) to
+  // cover both routes Nuxt may use to resolve useAppConfig in this test env.
+
+  describe("app.config resolution", () => {
+    beforeEach(() => {
+      // Stub the global so the component's useAppConfig() call is intercepted
+      // regardless of whether Nuxt resolves it via #imports or the global scope.
+      vi.stubGlobal("useAppConfig", useAppConfigMock);
+      useAppConfigMock.mockImplementation(() => ({ srcdev: undefined, icon: {} }));
+    });
+
+    it("uses hardcoded fallbacks when app.config has no displayToast key", async () => {
+      await mountAndShow();
+      expect(toast()!.getAttribute("data-theme")).toBe("info");
+      expect(toast()!.classList).toContain("top");
+      expect(toast()!.classList).toContain("right");
+      expect(document.querySelector(".display-toast-progress")).not.toBeNull();
+    });
+
+    it("uses app.config autoDismiss:false when no config prop is supplied", async () => {
+      // autoDismiss defaults to true (both hardcoded and real app.config), so false
+      // is the only value that proves the mock is being read.
+      useAppConfigMock.mockImplementation(() => ({
+        icon: {},
+        srcdev: { displayToast: { behavior: { autoDismiss: false } } },
+      }));
+      await mountAndShow();
+      expect(document.querySelector(".display-toast-progress")).toBeNull();
+      expect(document.querySelector("[data-test-id='alert-dismiss']")).not.toBeNull();
+    });
+
+    it("config prop takes precedence over app.config", async () => {
+      useAppConfigMock.mockImplementation(() => ({
+        icon: {},
+        srcdev: { displayToast: { appearance: { theme: "success", position: "bottom" } } },
+      }));
+      await mountAndShow({ config: { appearance: { theme: "warning", position: "top" } } });
+      expect(toast()!.getAttribute("data-theme")).toBe("warning");
+      expect(toast()!.classList).toContain("top");
+    });
   });
 });

--- a/app/components/02.molecules/alert-content/AlertContentInner.vue
+++ b/app/components/02.molecules/alert-content/AlertContentInner.vue
@@ -2,7 +2,7 @@
   <div class="alert-content-inner">
     <div class="alert-content-icon" data-test-id="alert-icon" aria-hidden="true">
       <slot name="icon">
-        <Icon :name="customIcon || defaultThemeIcons[theme]" class="icon" />
+        <Icon :name="customIcon || themeIcon" class="icon" />
       </slot>
     </div>
 
@@ -23,7 +23,7 @@
       @click.prevent="emit('dismiss')"
     >
       <slot name="dismissIcon">
-        <Icon name="material-symbols:close" class="icon" />
+        <Icon :name="dismissIcon" class="icon" />
       </slot>
       <span class="sr-only">
         <slot name="dismissLabel">Close</slot>
@@ -43,7 +43,7 @@ interface Props {
   ariaLive?: "polite" | "assertive" | "off";
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   customIcon: undefined,
   dismissible: false,
   contentId: undefined,
@@ -54,12 +54,20 @@ const emit = defineEmits<{ dismiss: [] }>();
 
 const slots = useSlots();
 
-const defaultThemeIcons: Record<SemanticTheme, string> = {
+const appConfig = useAppConfig();
+
+const fallbackIcons: Record<SemanticTheme, string> = {
   info: "akar-icons:info",
   success: "akar-icons:check",
   warning: "akar-icons:circle-alert",
   error: "akar-icons:circle-alert",
 };
+
+const themeIcon = computed(() => {
+  const icons = appConfig.srcdev?.alertContent?.icons as Partial<Record<SemanticTheme, string>> | undefined;
+  return icons?.[props.theme] ?? fallbackIcons[props.theme];
+});
+const dismissIcon = computed(() => appConfig.srcdev?.alertContent?.dismissIcon ?? "material-symbols:close");
 </script>
 
 <style lang="css">

--- a/app/types/app-config.d.ts
+++ b/app/types/app-config.d.ts
@@ -1,0 +1,17 @@
+import type { SemanticTheme } from "./components"
+
+declare module "@nuxt/schema" {
+  interface AppConfigInput {
+    srcdev?: {
+      displayDialog?: {
+        variant?: "dialog" | "modal" | "confirm" | "alert" | "fullscreen"
+        justifyDialog?: "start" | "center" | "end"
+        alignDialog?: "start" | "center" | "end"
+        lockViewport?: boolean
+        allowContentScroll?: boolean
+        theme?: SemanticTheme
+        closeIcon?: string
+      }
+    }
+  }
+}

--- a/app/types/app-config.d.ts
+++ b/app/types/app-config.d.ts
@@ -1,8 +1,32 @@
-import type { SemanticTheme } from "./components"
+import type { SemanticTheme, DisplayPromptTheme, DisplayToastTheme, DisplayToastPosition, DisplayToastAlignment } from "./components"
 
 declare module "@nuxt/schema" {
   interface AppConfigInput {
     srcdev?: {
+      alertContent?: {
+        icons?: Partial<Record<SemanticTheme, string>>
+        dismissIcon?: string
+      }
+      displayPrompt?: {
+        theme?: DisplayPromptTheme
+        dismissible?: boolean
+        useAutoFocus?: boolean
+        masked?: boolean
+      }
+      displayToast?: {
+        appearance?: {
+          theme?: DisplayToastTheme
+          position?: DisplayToastPosition
+          alignment?: DisplayToastAlignment
+          fullWidth?: boolean
+          masked?: boolean
+        }
+        behavior?: {
+          autoDismiss?: boolean
+          duration?: number
+          revealDuration?: number
+        }
+      }
       displayDialog?: {
         variant?: "dialog" | "modal" | "confirm" | "alert" | "fullscreen"
         justifyDialog?: "start" | "center" | "end"


### PR DESCRIPTION
```markdown
## Summary

Introduces `app.config`-based defaults for four components — `DisplayDialog`, `DisplayPrompt`, `DisplayToast`, and `AlertContentInner` — so consumers can configure site-wide behaviour once in their own `app.config.ts` instead of repeating props at every usage site.

## Changes

- **`app/app.config.ts`** (new) — Layer defaults for all four components under the `srcdev.*` namespace. Nuxt deep-merges consumer overrides at build time.
- **`app/types/app-config.d.ts`** (new) — `AppConfigInput` module augmentation so consumer `defineAppConfig` calls are fully type-safe.
- **`DisplayDialog.vue`** — Props that had hardcoded `withDefaults` values now default to `undefined`; a `resolved` computed object applies the prop → app.config → fallback chain. `closeIcon` is now configurable.
- **`DisplayPrompt.vue`** — Same `resolved` computed pattern; `theme`, `dismissible`, `useAutoFocus`, and `masked` are all app.config-configurable.
- **`DisplayToast.vue`** — App.config fallback inserted into existing individual computed props (`theme`, `position`, `alignment`, `fullWidth`, `masked`, `autoDismiss`, `duration`, `revealDuration`). Per-instance `content` and `returnFocusTo` are excluded.
- **`AlertContentInner.vue`** — Theme icons and dismiss icon now resolved via `app.config.srcdev.alertContent`; one config change covers every toast, prompt, and alert in the app.
- **`.gitignore`** — Added `.claude/projects/` to prevent machine-specific Claude session data leaking into the repo.
- **`.claude/skills/`** — Skill docs updated/added for all four components documenting the app.config defaults section and resolution chain.

## Testing

- All existing unit tests pass (`npm run test:run`).
- Resolution chain (explicit prop wins over app.config wins over hardcoded fallback) verified manually.
- Boolean props use explicit `undefined` defaults in `withDefaults` to prevent Vue's boolean-casting from swallowing absent values before the `??` fallthrough fires.

## Notes

- `undefined as SemanticTheme | undefined` type assertion is required in `defineAppConfig` for optional fields that can be `undefined` — without it, Nuxt's generated `AppConfig` type omits the key entirely.
- The `alertContent` key is intentionally separate from `displayToast` because `AlertContentInner` is shared infrastructure beneath `AlertContent`, `AlertMaskedContent`, `DisplayToast`, and `DisplayPrompt`.
```
